### PR TITLE
Move dependabot-auto-merge workflow to central repo

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -1,0 +1,49 @@
+# see https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
+
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@c9c4182bf1b97f5224aee3906fd373f6b61b4526 # v1.6.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Check whether anyone besides dependabot has pushed
+        id: pr_author
+        run: |
+          EXTRA_AUTHORS=$(gh pr view "$PR_URL" --json commits --jq '.commits[] | .authors[] | .login' | sort | uniq | grep -v dependabot || echo -n '')
+          if [ -n "$EXTRA_AUTHORS" ]; then
+            echo "PR has authors in addition to dependabot: $EXTRA_AUTHORS"
+            echo "human_pushed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "human_pushed=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Enable auto-merge for Dependabot PRs
+        if: >
+            ( steps.pr_author.human_pushed != 'true' ) &&
+            ( steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' )
+        run: gh pr merge --auto --squash "$PR_URL" && gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Disable auto-merge if human modified PR
+        if: steps.pr_author.human_pushed == 'true'
+        run: |
+          echo "disabling auto-merge due to non-dependabot push"
+          gh pr merge --disable-auto "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+


### PR DESCRIPTION
Otherwise we will have copies of it everywhere.

Converting to a draft because it's not ready yet; needs to be tweaked to run in the workflow context instead of the PR context when called from another repo.