### PR TITLE
Manage awaiting response label on issues

### DIFF
--- a/.github/workflows/oss-project-board-add.yaml
+++ b/.github/workflows/oss-project-board-add.yaml
@@ -1,8 +1,7 @@
 name: Add issues and PRs to the OSS community project board
 
-on: 
+on:
   workflow_call:
-
     inputs:
       project_url:
         default: https://github.com/orgs/anchore/projects/22
@@ -11,7 +10,7 @@ on:
 
       users:
         # TODO: replace me with an org-based or team-based check
-        default: '["wagoodman", "dependabot", "tgerla", "kzantow", "willmurphyscode", "spiffcs", "westonsteimel", "zhill", "nurmi"]'
+        default: '["wagoodman", "dependabot", "tgerla", "kzantow", "willmurphyscode", "spiffcs", "westonsteimel", "zhill", "nurmi", "popey"]'
         description: "JSON list as string of users to ignore"
         type: string
 
@@ -20,9 +19,7 @@ on:
         description: "The classic GitHub token (with project access) to use for authentication"
         required: true
 
-
 jobs:
-
   # useful for debugging issues
 
   # show-info:
@@ -80,7 +77,7 @@ jobs:
   #         echo "Event Name: ${{ github.event_name }}"
   #         echo "Number: ${{ github.event.issue.number }}"
   #         echo "PR Author: ${{ github.event.pull_request.user.login }}"
-  
+
   #     - uses: actions/add-to-project@v0.5.0
   #       with:
   #         project-url: ${{ inputs.project_url }}

--- a/.github/workflows/remove-awaiting-response-label.yaml
+++ b/.github/workflows/remove-awaiting-response-label.yaml
@@ -1,0 +1,34 @@
+# remove-awaiting-response-label.yaml
+name: "Manage Awaiting Response Label"
+on:
+  workflow_call:
+    inputs:
+      users:
+        # TODO: replace me with an org-based or team-based check
+        default: '["wagoodman", "tgerla", "kzantow", "willmurphyscode", "spiffcs", "westonsteimel", "zhill", "nurmi", "popey"]'
+        description: "JSON list as string of users to ignore"
+        type: string
+
+    secrets:
+      token:
+        description: "The classic GitHub token (with project access) to use for authentication"
+        required: true
+
+jobs:
+  remove-awaiting-response:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'issue_comment'
+    steps:
+      - name: Show event info
+        run: |
+          echo "Event Name: ${{ github.event_name }}"
+          echo "Number: ${{ github.event.issue.number }}"
+          echo "Issue Author: ${{ github.event.issue.user.login }}"
+
+      - name: Remove Awaiting Response Label
+        if: |
+          !contains(fromJson( inputs.users ), github.event.issue.user.login) && github.event.issue.user.login != ''
+        run: |
+          gh issue edit --repo ${{ github.event.repository.full_name }} ${{ github.event.issue.number }} --remove-label 'awaiting-response'
+        env:
+          GH_TOKEN: ${{ secrets.token }}


### PR DESCRIPTION
This PR adds a new workflow that will automatically remove the `awaiting-response` label from the given issue. This is intended to be used with the following workflow in the target repo:

```
name: "Manage Awaiting Response Label"

on:
  issue_comment:
    types: [created]

jobs:
  run:
    uses: "anchore/workflows/.github/workflows/remove-awaiting-response-label.yaml@main"
    secrets:
      token: ${{ secrets.OSS_PROJECT_GH_TOKEN }}

```