### PR TITLE
fix: only remove awaiting response for issues, not PRs

### DIFF
--- a/.github/workflows/remove-awaiting-response-label.yaml
+++ b/.github/workflows/remove-awaiting-response-label.yaml
@@ -31,7 +31,7 @@ on:
 jobs:
   remove-awaiting-response:
     runs-on: ubuntu-latest
-    if: github.event_name == 'issue_comment'
+    if: ${{ github.event_name == 'issue_comment' && !github.event.issue.pull_request }}
     steps:
       - name: Show event info
         run: |


### PR DESCRIPTION
This workflow is running when commenting on PRs, it looks like: https://github.com/anchore/syft/actions/runs/11070988431/job/30761814598#step:3:33

This PR updates the workflow to only run for issues, not PRs.