### PR TITLE
Add release train nudger workflow

### DIFF
--- a/.github/actions/changelog/action.yaml
+++ b/.github/actions/changelog/action.yaml
@@ -1,0 +1,50 @@
+name: "Generate Changelog"
+description: "Checkout repository, run make changelog, and save output."
+inputs:
+  repository:
+    description: "The GitHub repository to check out."
+    required: true
+  path:
+    description: "The path where the repository will be checked out."
+    required: true
+  github_token:
+    description: "GitHub token for authentication."
+    required: true
+outputs:
+  changelog:
+    description: "The content of the CHANGELOG.md file."
+    value: ${{ steps.save.outputs.changelog }}
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ inputs.repository }}
+        path: ${{ inputs.path }}
+        fetch-depth: 0
+
+    - name: Cache .tool directory
+      uses: actions/cache@v3
+      with:
+        path: ${{ inputs.path }}/.tool
+        key: tool-cache-${{ runner.os }}-${{ inputs.repository }}-${{ hashFiles('${{ inputs.path }}/.binny.yaml') }}
+        restore-keys: |
+          tool-cache-${{ runner.os }}-${{ inputs.repository }}-
+
+    - name: Run `make changelog`
+      working-directory: ${{ inputs.path }}
+      shell: bash
+      run: |
+        make changelog
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+
+    - name: Save changelog output
+      id: save
+      working-directory: ${{ inputs.path }}
+      shell: bash
+      run: |
+        echo "changelog<<EOF" >> $GITHUB_OUTPUT
+        cat CHANGELOG.md >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-train-nudger.yaml
+++ b/.github/workflows/release-train-nudger.yaml
@@ -1,0 +1,58 @@
+name: Nudge team to start releases
+
+on:
+  workflow_dispatch:
+
+  # run every other monday at 1 PM UTC
+  schedule:
+    - cron: "0 13 * * 1/2"
+
+jobs:
+  clone-and-generate:
+    name: Generate changelog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Stereoscope changelog
+        id: stereoscope
+        uses: ./.github/actions/changelog
+        with:
+          repository: anchore/stereoscope
+          path: stereoscope
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Syft changelog
+        id: syft
+        uses: ./.github/actions/changelog
+        with:
+          repository: anchore/syft
+          path: syft
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Grype changelog
+        id: grype
+        uses: ./.github/actions/changelog
+        with:
+          repository: anchore/grype
+          path: grype
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Craft slack payload
+        run: |
+          jq -n --arg syft "${{ steps.syft.outputs.changelog }}" \
+                --arg stereoscope "${{ steps.stereoscope.outputs.changelog }}" \
+                --arg grype "${{ steps.grype.outputs.changelog }}" \
+                '{ "syft-changelog": $syft, "stereoscope-changelog": $stereoscope, "grype-changelog": $grype }' \
+          > payload.json
+
+      - name: Show the payload
+        run: |
+          cat payload.json
+
+      - name: Send slack notification
+        run: |
+          curl -X POST -H 'Content-type: application/json' \
+            --data @payload.json \
+            ${{ secrets.RELEASE_NUDGER_WEBHOOK_URL }}


### PR DESCRIPTION
This workflow will run every other week at 1pm UTC on mondays and will generate changelogs for the steroscope, syft, and grype projects and notify the OSS team.