### PR TITLE
Create a tag action using deploy keys

### DIFF
--- a/.github/actions/binny/README.md
+++ b/.github/actions/binny/README.md
@@ -1,0 +1,64 @@
+# Binny
+
+A GitHub Action that installs project tools managed by [binny](https://github.com/anchore/binny) with caching support.
+
+## Why use this?
+
+Projects often have multiple CLI tools as development dependencies (linters, formatters, etc.). Binny manages these tools declaratively via a `.binny.yaml` file. This action:
+
+- Installs all tools defined in `.binny.yaml`
+- Caches the `.tool` directory between runs for faster CI
+- Verifies installed tools match the expected versions
+
+## Usage
+
+```yaml
+- uses: ./.github/actions/binny
+  with:
+    cache-key-prefix: "abc123"
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `cache-key-prefix` | No | `181053ac82` | Prefix for cache keys (change to invalidate cache) |
+
+## Outputs
+
+None.
+
+## Prerequisites
+
+The repository must have:
+- A `.binny.yaml` file defining the tools to install
+- A `Makefile` with a `tools` target that runs binny
+
+## Example Workflow
+
+```yaml
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install tools
+        uses: ./.github/actions/binny
+
+      - name: Run linter
+        run: .tool/golangci-lint run
+```
+
+## Cache Behavior
+
+The action caches the `.tool` directory based on:
+- The `cache-key-prefix` input
+- The runner OS
+- A hash of the `.binny.yaml` file
+
+To invalidate the cache, change the `cache-key-prefix` value.

--- a/.github/actions/bootstrap/README.md
+++ b/.github/actions/bootstrap/README.md
@@ -1,0 +1,58 @@
+# Bootstrap
+
+A GitHub Action that sets up a complete development environment by combining the `binny` and `python` actions.
+
+## Why use this?
+
+For projects that need both binny-managed tools and a Python environment, this action provides a single step to set up everything. It's a convenience wrapper that:
+
+- Installs all binny-managed tools (with caching)
+- Sets up Python with uv and project dependencies
+
+## Usage
+
+```yaml
+- uses: ./.github/actions/bootstrap
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `python-version` | No | `3.13` | Python version to install |
+| `cache-key-prefix` | No | `181053ac82` | Prefix for cache keys (change to invalidate cache) |
+
+## Outputs
+
+None.
+
+## Example Workflow
+
+```yaml
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up environment
+        uses: ./.github/actions/bootstrap
+        with:
+          python-version: "3.12"
+
+      - name: Run tests
+        run: pytest
+```
+
+## What It Does
+
+This action runs two sub-actions in sequence:
+
+1. **binny** - Installs CLI tools from `.binny.yaml`
+2. **python** - Sets up Python with uv and installs dependencies from `pyproject.toml`
+
+If you only need one of these, use the individual actions instead.

--- a/.github/actions/create-tag-via-deploy-key/README.md
+++ b/.github/actions/create-tag-via-deploy-key/README.md
@@ -1,0 +1,88 @@
+# Create Tag via Deploy Key
+
+A GitHub Action that creates and pushes git tags using an SSH deploy key for authentication, instead of the standard `GITHUB_TOKEN`.
+
+## Why use this?
+
+The default `GITHUB_TOKEN` has broad permissions that can be difficult to restrict. By using a deploy key with repository rulesets, you can:
+
+- Allow tag pushes while blocking direct code pushes
+- Maintain fine-grained control over what CI can modify
+- Comply with branch protection and tag protection rules
+
+## Usage
+
+```yaml
+- uses: ./.github/actions/create-tag-via-deploy-key
+  with:
+    tag: v1.2.3
+    deploy-key: ${{ secrets.DEPLOY_KEY }}
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `tag` | Yes | - | The tag to create (e.g., `v1.2.3`) |
+| `deploy-key` | Yes | - | SSH private key with write access to the repository |
+| `tag-message` | No | `Release <tag>` | Message for the annotated tag |
+| `git-user-name` | No | `github-actions[bot]` | Git user.name for the tag commit |
+| `git-user-email` | No | `github-actions[bot]@users.noreply.github.com` | Git user.email for the tag commit |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `tag` | The tag that was created |
+| `sha` | The commit SHA that was tagged |
+
+## Setting up a Deploy Key
+
+1. Generate an SSH key pair:
+   ```bash
+   ssh-keygen -t ed25519 -C "deploy-key" -f deploy_key -N ""
+   ```
+
+2. Add the **public key** (`deploy_key.pub`) as a deploy key in your repository:
+   - Go to Settings > Deploy keys > Add deploy key
+   - Check "Allow write access"
+
+3. Add the **private key** (`deploy_key`) as a repository secret:
+   - Go to Settings > Secrets and variables > Actions > New repository secret
+   - Name it `DEPLOY_KEY` (or your preferred name)
+   - Paste the entire private key content
+
+4. (Optional) Configure repository rulesets to restrict what the deploy key can do.
+
+## Example Workflow
+
+```yaml
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Determine version
+        id: version
+        run: echo "version=v1.0.0" >> $GITHUB_OUTPUT
+
+      - name: Create tag
+        uses: ./.github/actions/create-tag-via-deploy-key
+        with:
+          tag: ${{ steps.version.outputs.version }}
+          deploy-key: ${{ secrets.DEPLOY_KEY }}
+          tag-message: "Release ${{ steps.version.outputs.version }}"
+```
+
+## Limitations
+
+- Only works with GitHub repositories (uses `git@github.com` SSH URL)
+- Requires a deploy key with write access
+- Tag must not already exist locally or remotely

--- a/.github/actions/create-tag-via-deploy-key/action.yaml
+++ b/.github/actions/create-tag-via-deploy-key/action.yaml
@@ -1,0 +1,51 @@
+name: 'Create Tag via Deploy Key'
+description: 'Creates and pushes a git tag using a deploy key for authentication'
+
+inputs:
+  tag:
+    description: 'The tag to create (e.g., v1.2.3)'
+    required: true
+  deploy-key:
+    description: 'SSH private key with write access to the repository'
+    required: true
+  tag-message:
+    description: 'Annotated tag message (defaults to "Release <tag>")'
+    required: false
+    default: ''
+  git-user-name:
+    description: 'Git user.name for the tag commit'
+    required: false
+    default: 'github-actions[bot]'
+  git-user-email:
+    description: 'Git user.email for the tag commit'
+    required: false
+    default: 'github-actions[bot]@users.noreply.github.com'
+
+outputs:
+  tag:
+    description: 'The tag that was created'
+    value: ${{ inputs.tag }}
+  sha:
+    description: 'The commit SHA that was tagged'
+    value: ${{ steps.create-tag.outputs.sha }}
+
+runs:
+  using: composite
+  steps:
+    - name: Create and push tag
+      id: create-tag
+      shell: bash
+      env:
+        INPUT_TAG: ${{ inputs.tag }}
+        INPUT_DEPLOY_KEY: ${{ inputs.deploy-key }}
+        INPUT_TAG_MESSAGE: ${{ inputs.tag-message }}
+        INPUT_GIT_USER_NAME: ${{ inputs.git-user-name }}
+        INPUT_GIT_USER_EMAIL: ${{ inputs.git-user-email }}
+        INPUT_REPOSITORY: ${{ github.repository }}
+      run: |
+        python3 "${{ github.action_path }}/create_tag.py" \
+          --tag "$INPUT_TAG" \
+          --tag-message "$INPUT_TAG_MESSAGE" \
+          --git-user-name "$INPUT_GIT_USER_NAME" \
+          --git-user-email "$INPUT_GIT_USER_EMAIL" \
+          --repository "$INPUT_REPOSITORY"

--- a/.github/actions/create-tag-via-deploy-key/create_tag.py
+++ b/.github/actions/create-tag-via-deploy-key/create_tag.py
@@ -1,0 +1,825 @@
+#!/usr/bin/env python3
+"""
+Create and push a git tag using a deploy key for authentication.
+
+This script provides a secure way to push tags from CI without using
+overly-permissive GITHUB_TOKEN permissions. By using a deploy key with
+repository rulesets, we can allow tag pushes while blocking code pushes.
+
+Security features:
+- All subprocess calls use list arguments (no shell injection possible)
+- Deploy key is loaded into ssh-agent via stdin (never written to disk)
+- Input validation rejects potentially dangerous characters
+- Output sanitization prevents GITHUB_OUTPUT injection
+- Cleanup runs even on failure via context managers (agent is killed)
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shlex
+import signal
+import stat
+import subprocess
+import sys
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import NamedTuple
+
+# full paths to executables on GitHub runners (Linux)
+# this satisfies S607 (partial executable path) security checks
+GIT_PATH = "/usr/bin/git"
+SSH_AGENT_PATH = "/usr/bin/ssh-agent"
+SSH_ADD_PATH = "/usr/bin/ssh-add"
+
+# GitHub's official SSH host keys.
+# Source: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints
+#
+# To verify or update these keys:
+#
+#   Method 1 - Using GitHub's REST API (recommended, machine-readable):
+#     curl -s https://api.github.com/meta | jq -r '.ssh_keys[]' | while read key; do
+#       echo "github.com $key"
+#     done
+#
+#   Method 2 - Using ssh-keyscan:
+#     ssh-keyscan github.com 2>/dev/null | sort
+#
+#   Method 3 - Verify fingerprints against documentation:
+#     https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints
+#     You can compute fingerprints with: ssh-keygen -lf <(echo "KEY_LINE_HERE")
+#
+# API documentation: https://docs.github.com/en/rest/meta/meta#get-github-meta-information
+#
+# IMPORTANT: These keys are validated against the GitHub API in test_create_tag.py.
+# If GitHub rotates their keys, the test will fail and these values must be updated.
+
+# individual SSH public keys from GitHub (without the "github.com" prefix)
+# these are the raw key values as returned by the GitHub /meta API endpoint
+GITHUB_SSH_KEY_ED25519 = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl"
+GITHUB_SSH_KEY_ECDSA = "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg="  # noqa: E501
+GITHUB_SSH_KEY_RSA = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk="  # noqa: E501
+
+# tuple of all GitHub SSH keys for iteration
+GITHUB_SSH_KEYS = (
+    GITHUB_SSH_KEY_ED25519,
+    GITHUB_SSH_KEY_ECDSA,
+    GITHUB_SSH_KEY_RSA,
+)
+
+
+def get_github_ssh_host_keys() -> str:
+    """Generate the known_hosts file content for GitHub.
+
+    Returns:
+        A string suitable for writing to a known_hosts file, with each key
+        prefixed by "github.com ".
+    """
+    return "\n".join(f"github.com {key}" for key in GITHUB_SSH_KEYS)
+
+
+class Config(NamedTuple):
+    """Validated configuration for the tag operation."""
+
+    tag: str
+    deploy_key: str
+    tag_message: str
+    git_user_name: str
+    git_user_email: str
+    repository: str
+
+
+class ValidationError(Exception):
+    """Raised when input validation fails."""
+
+
+class GitError(Exception):
+    """Raised when a git operation fails."""
+
+
+# pattern for valid git tag names (conservative subset)
+# allows: alphanumeric, dots, dashes, underscores, slashes
+# disallows: spaces, shell metacharacters, control characters
+TAG_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._/-]{0,255}$")
+
+# pattern for valid git user name/email (conservative)
+# rejects shell metacharacters and control characters
+SAFE_STRING_PATTERN = re.compile(r"^[a-zA-Z0-9@._\-\[\] ]{1,256}$")
+
+
+def validate_tag(tag: str | None) -> str:
+    """Validate tag name.
+
+    Args:
+        tag: The tag name to validate.
+
+    Returns:
+        The validated tag name.
+
+    Raises:
+        ValidationError: If the tag is invalid.
+    """
+    if not tag:
+        raise ValidationError("tag is required")
+
+    if not TAG_PATTERN.match(tag):
+        raise ValidationError(
+            f"tag contains invalid characters or format: '{tag}'. "
+            "Must start with alphanumeric and contain only alphanumeric, dots, dashes, underscores, or slashes"
+        )
+
+    # additional safety checks
+    if tag.startswith("-"):
+        raise ValidationError("tag cannot start with a dash")
+
+    if ".." in tag:
+        raise ValidationError("tag cannot contain '..'")
+
+    if tag.endswith(".lock"):
+        raise ValidationError("tag cannot end with '.lock'")
+
+    return tag
+
+
+def validate_safe_string(value: str | None, field_name: str) -> str:
+    """Validate a string contains only safe characters.
+
+    Args:
+        value: The string to validate.
+        field_name: Name of the field for error messages.
+
+    Returns:
+        The validated string.
+
+    Raises:
+        ValidationError: If the string is invalid.
+    """
+    if not value:
+        raise ValidationError(f"{field_name} is required")
+
+    if not SAFE_STRING_PATTERN.match(value):
+        raise ValidationError(
+            f"{field_name} contains invalid characters: '{value}'. "
+            "Must contain only alphanumeric, @, dots, dashes, underscores, brackets, or spaces"
+        )
+
+    return value
+
+
+def validate_repository(repository: str | None) -> str:
+    """Validate repository format.
+
+    Args:
+        repository: The repository in 'owner/repo' format.
+
+    Returns:
+        The validated repository string.
+
+    Raises:
+        ValidationError: If the repository format is invalid.
+    """
+    if not repository:
+        raise ValidationError("repository is required")
+
+    if "/" not in repository or repository.count("/") != 1:
+        raise ValidationError(f"repository must be in 'owner/repo' format, got: {repository}")
+
+    owner, repo = repository.split("/")
+    if not owner or not repo:
+        raise ValidationError(f"repository must be in 'owner/repo' format, got: {repository}")
+
+    # validate characters (GitHub allows alphanumeric, dash, underscore, dot)
+    repo_pattern = re.compile(r"^[a-zA-Z0-9._-]+$")
+    if not repo_pattern.match(owner) or not repo_pattern.match(repo):
+        raise ValidationError(f"repository contains invalid characters: {repository}")
+
+    return repository
+
+
+def validate_deploy_key(deploy_key: str | None) -> str:
+    """Validate deploy key format.
+
+    Args:
+        deploy_key: The SSH private key.
+
+    Returns:
+        The validated deploy key.
+
+    Raises:
+        ValidationError: If the deploy key is invalid.
+    """
+    if not deploy_key:
+        raise ValidationError("deploy_key is required")
+
+    # size limit to prevent memory exhaustion (16KB is generous for SSH keys)
+    max_key_size = 16 * 1024
+    if len(deploy_key) > max_key_size:
+        raise ValidationError(f"deploy_key exceeds maximum size of {max_key_size} bytes")
+
+    # reject null bytes which could cause truncation issues
+    if "\x00" in deploy_key:
+        raise ValidationError("deploy_key contains invalid null bytes")
+
+    # check for valid PEM format - must have matching BEGIN/END markers
+    # this prevents attacks where someone embeds "PRIVATE KEY-----" in a comment
+    stripped = deploy_key.strip()
+
+    # valid private key headers we accept
+    valid_headers = (
+        "-----BEGIN OPENSSH PRIVATE KEY-----",
+        "-----BEGIN RSA PRIVATE KEY-----",
+        "-----BEGIN DSA PRIVATE KEY-----",
+        "-----BEGIN EC PRIVATE KEY-----",
+        "-----BEGIN PRIVATE KEY-----",  # PKCS#8 format
+    )
+
+    header_found = None
+    for header in valid_headers:
+        if stripped.startswith(header):
+            header_found = header
+            break
+
+    if not header_found:
+        raise ValidationError(
+            "deploy_key does not appear to be a valid SSH private key (must start with a valid private key header)"
+        )
+
+    # verify the corresponding END marker exists
+    expected_footer = header_found.replace("BEGIN", "END")
+    if not stripped.endswith(expected_footer):
+        raise ValidationError(
+            "deploy_key does not appear to be a valid SSH private key (missing or invalid end marker)"
+        )
+
+    return deploy_key
+
+
+def validate_config(
+    tag: str | None,
+    deploy_key: str | None,
+    tag_message: str | None,
+    git_user_name: str | None,
+    git_user_email: str | None,
+    repository: str | None,
+) -> Config:
+    """Validate all inputs and return a Config object.
+
+    Args:
+        tag: The tag to create.
+        deploy_key: SSH private key.
+        tag_message: Message for the annotated tag.
+        git_user_name: Git user.name for the tag.
+        git_user_email: Git user.email for the tag.
+        repository: Repository in 'owner/repo' format.
+
+    Returns:
+        A validated Config object.
+
+    Raises:
+        ValidationError: If any input is invalid.
+    """
+    # validate all inputs (fail-fast on first error)
+    validated_tag = validate_tag(tag)
+    validated_deploy_key = validate_deploy_key(deploy_key)
+    validated_repository = validate_repository(repository)
+    validated_git_user_name = validate_safe_string(git_user_name, "git_user_name")
+    validated_git_user_email = validate_safe_string(git_user_email, "git_user_email")
+
+    # tag_message is optional, but if provided, validate it
+    final_tag_message = tag_message if tag_message else f"Release {validated_tag}"
+
+    # validate tag message doesn't contain control characters (except newlines)
+    if final_tag_message and re.search(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", final_tag_message):
+        raise ValidationError("tag_message contains invalid control characters")
+
+    # limit tag message length to prevent resource exhaustion
+    max_tag_message_length = 4096
+    if len(final_tag_message) > max_tag_message_length:
+        raise ValidationError(f"tag_message exceeds maximum length of {max_tag_message_length} characters")
+
+    return Config(
+        tag=validated_tag,
+        deploy_key=validated_deploy_key,
+        tag_message=final_tag_message,
+        git_user_name=validated_git_user_name,
+        git_user_email=validated_git_user_email,
+        repository=validated_repository,
+    )
+
+
+def run_git(args: list[str], env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    """Run a git command securely.
+
+    Args:
+        args: Git command arguments (without 'git' prefix).
+        env: Optional environment variables to add.
+
+    Returns:
+        CompletedProcess with stdout/stderr captured.
+
+    Raises:
+        GitError: If the git command fails.
+    """
+    cmd = [GIT_PATH, *args]
+
+    # merge with current environment
+    full_env = os.environ.copy()
+    if env:
+        full_env.update(env)
+
+    try:
+        result = subprocess.run(  # noqa: S603 - cmd is built from validated inputs
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,  # we'll check manually for better error messages
+            env=full_env,
+        )
+    except OSError as e:
+        raise GitError(f"Failed to execute git: {e}") from e
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip() if result.stderr else "no error output"
+        raise GitError(f"git {args[0]} failed: {stderr}")
+
+    return result
+
+
+def get_git_config(key: str) -> str | None:
+    """Get a git config value, returning None if not set.
+
+    Args:
+        key: The config key to get.
+
+    Returns:
+        The config value, or None if not set.
+    """
+    try:
+        result = subprocess.run(  # noqa: S603 - key is used as git config key, not shell command
+            [GIT_PATH, "config", "--get", key],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+        return None
+    except OSError:
+        return None
+
+
+def set_git_config(key: str, value: str) -> None:
+    """Set a git config value.
+
+    Args:
+        key: The config key to set.
+        value: The value to set.
+    """
+    run_git(["config", key, value])
+
+
+def unset_git_config(key: str) -> None:
+    """Unset a git config value, ignoring errors if not set.
+
+    Args:
+        key: The config key to unset.
+    """
+    try:
+        subprocess.run(  # noqa: S603 - key is used as git config key, not shell command
+            [GIT_PATH, "config", "--unset", key],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        pass
+
+
+class SSHConfig(NamedTuple):
+    """SSH configuration returned by setup_ssh_key."""
+
+    auth_sock: str  # SSH_AUTH_SOCK path for ssh-agent
+    agent_pid: int  # ssh-agent PID for cleanup
+    known_hosts_path: str
+
+
+def _parse_agent_var(output: str, var_name: str) -> str:
+    """Parse a variable from ssh-agent -s output.
+
+    Args:
+        output: The stdout from ssh-agent -s.
+        var_name: The variable name to extract (e.g., SSH_AUTH_SOCK).
+
+    Returns:
+        The value of the variable.
+
+    Raises:
+        RuntimeError: If the variable cannot be parsed.
+    """
+    # output format: SSH_AUTH_SOCK=/tmp/ssh-xxx/agent.123; export SSH_AUTH_SOCK;
+    match = re.search(rf"{var_name}=([^;]+);", output)
+    if not match:
+        raise RuntimeError(f"failed to parse {var_name} from ssh-agent output")
+    return match.group(1)
+
+
+@contextmanager
+def setup_ssh_key(deploy_key: str) -> Iterator[SSHConfig]:
+    """Set up SSH key in ssh-agent and known_hosts in a secure temp directory.
+
+    Uses ssh-agent to hold the key in memory, avoiding disk writes for the
+    private key material. The known_hosts file is still written to disk as
+    it contains only GitHub's public host keys (not sensitive).
+
+    Args:
+        deploy_key: The SSH private key content.
+
+    Yields:
+        SSHConfig with the agent socket path, agent PID, and known_hosts path.
+    """
+    agent_pid: int | None = None
+
+    # still need temp dir for known_hosts (required for MITM protection)
+    with tempfile.TemporaryDirectory(prefix="deploy_key_") as tmpdir:
+        tmpdir_path = Path(tmpdir)
+        os.chmod(tmpdir_path, stat.S_IRWXU)  # 700
+
+        # write known_hosts with GitHub's official SSH host keys
+        known_hosts_path = tmpdir_path / "known_hosts"
+        known_hosts_path.touch(mode=stat.S_IRUSR | stat.S_IWUSR)  # 600
+        known_hosts_path.write_text(get_github_ssh_host_keys() + "\n")
+
+        try:
+            # start ssh-agent and parse output
+            result = subprocess.run(  # noqa: S603 - using hardcoded SSH_AGENT_PATH constant
+                [SSH_AGENT_PATH, "-s"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+            # parse SSH_AUTH_SOCK and SSH_AGENT_PID from output
+            auth_sock = _parse_agent_var(result.stdout, "SSH_AUTH_SOCK")
+            agent_pid = int(_parse_agent_var(result.stdout, "SSH_AGENT_PID"))
+
+            # set environment for ssh-add
+            env = os.environ.copy()
+            env["SSH_AUTH_SOCK"] = auth_sock
+
+            # load key into agent via stdin (no disk write)
+            subprocess.run(  # noqa: S603 - using hardcoded SSH_ADD_PATH, input is validated
+                [SSH_ADD_PATH, "-"],
+                input=deploy_key,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+            yield SSHConfig(
+                auth_sock=auth_sock,
+                agent_pid=agent_pid,
+                known_hosts_path=str(known_hosts_path),
+            )
+        finally:
+            # kill the ssh-agent process
+            if agent_pid is not None:
+                try:
+                    os.kill(agent_pid, signal.SIGTERM)
+                except OSError:
+                    pass  # agent may have already exited
+
+
+def tag_exists_locally(tag: str) -> bool:
+    """Check if a tag exists locally.
+
+    Args:
+        tag: The tag name to check.
+
+    Returns:
+        True if the tag exists locally.
+    """
+    try:
+        run_git(["rev-parse", tag])
+        return True
+    except GitError:
+        return False
+
+
+def tag_exists_remotely(tag: str) -> bool:
+    """Check if a tag exists on the remote.
+
+    Args:
+        tag: The tag name to check.
+
+    Returns:
+        True if the tag exists on the remote.
+    """
+    try:
+        result = run_git(["ls-remote", "--tags", "origin", tag])
+        # check for exact ref match to avoid substring false positives
+        # (e.g., "v1.0" matching "v1.0.0")
+        # ls-remote output format: "<sha>\trefs/tags/<tag>"
+        expected_ref = f"refs/tags/{tag}"
+        for line in result.stdout.strip().splitlines():
+            if not line:
+                continue
+            parts = line.split("\t")
+            if len(parts) >= 2 and parts[1] == expected_ref:
+                return True
+        return False
+    except GitError:
+        return False
+
+
+def _restore_git_config(key: str, original_value: str | None) -> None:
+    """Restore a git config value to its original state.
+
+    Args:
+        key: The config key to restore.
+        original_value: The original value (None if was not set).
+    """
+    if original_value is None:
+        unset_git_config(key)
+    else:
+        set_git_config(key, original_value)
+
+
+def create_and_push_tag(config: Config) -> str:
+    """Create and push a git tag using the deploy key.
+
+    Args:
+        config: Validated configuration.
+
+    Returns:
+        The commit SHA that was tagged.
+
+    Raises:
+        GitError: If any git operation fails.
+        ValidationError: If the tag already exists.
+    """
+    # save original git config values for restoration
+    original_ssh_command = get_git_config("core.sshCommand")
+    original_remote_url = get_git_config("remote.origin.url")
+    original_user_name = get_git_config("user.name")
+    original_user_email = get_git_config("user.email")
+
+    with setup_ssh_key(config.deploy_key) as ssh_config:
+        try:
+            # configure git to use ssh-agent with strict host verification
+            # IdentityAgent specifies the agent socket (key is loaded in memory)
+            # shlex.quote() prevents command injection via path manipulation
+            # StrictHostKeyChecking=yes with pre-populated known_hosts prevents MITM attacks
+            ssh_command = (
+                f"ssh -o IdentityAgent={shlex.quote(ssh_config.auth_sock)} "
+                f"-o UserKnownHostsFile={shlex.quote(ssh_config.known_hosts_path)} "
+                f"-o StrictHostKeyChecking=yes "
+                f"-o BatchMode=yes"
+            )
+            set_git_config("core.sshCommand", ssh_command)
+
+            # set remote URL to SSH
+            ssh_url = f"git@github.com:{config.repository}.git"
+            run_git(["remote", "set-url", "origin", ssh_url])
+
+            # configure git user
+            set_git_config("user.name", config.git_user_name)
+            set_git_config("user.email", config.git_user_email)
+
+            # check if tag already exists
+            if tag_exists_locally(config.tag):
+                raise ValidationError(f"tag '{config.tag}' already exists locally")
+
+            if tag_exists_remotely(config.tag):
+                raise ValidationError(f"tag '{config.tag}' already exists on remote")
+
+            # create annotated tag
+            run_git(["tag", "-a", config.tag, "-m", config.tag_message])
+
+            # push tag
+            print(f"Pushing tag {config.tag} to origin...")
+            run_git(["push", "origin", config.tag])
+
+            # get the commit SHA
+            result = run_git(["rev-parse", "HEAD"])
+            sha = result.stdout.strip()
+
+            print(f"Successfully created and pushed tag {config.tag} at {sha}")
+            return sha
+        finally:
+            # restore original git config values
+            # wrap each in try/except to ensure all cleanup attempts run
+            restore_errors: list[str] = []
+
+            try:
+                _restore_git_config("core.sshCommand", original_ssh_command)
+            except GitError as e:
+                restore_errors.append(f"core.sshCommand: {e}")
+
+            try:
+                if original_remote_url is not None:
+                    run_git(["remote", "set-url", "origin", original_remote_url])
+            except GitError as e:
+                restore_errors.append(f"remote.origin.url: {e}")
+
+            try:
+                _restore_git_config("user.name", original_user_name)
+            except GitError as e:
+                restore_errors.append(f"user.name: {e}")
+
+            try:
+                _restore_git_config("user.email", original_user_email)
+            except GitError as e:
+                restore_errors.append(f"user.email: {e}")
+
+            # log any restore failures (but don't fail the operation)
+            if restore_errors:
+                print("Warning: Failed to restore some git config values:", file=sys.stderr)
+                for error in restore_errors:
+                    print(f"  - {error}", file=sys.stderr)
+
+
+def validate_output_name(name: str) -> str:
+    """Validate and sanitize an output name for GITHUB_OUTPUT.
+
+    Args:
+        name: The output name to validate.
+
+    Returns:
+        The validated output name.
+
+    Raises:
+        ValueError: If the name is invalid.
+    """
+    if not name:
+        raise ValueError("output name cannot be empty")
+
+    # output names must be alphanumeric with underscores only
+    if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", name):
+        raise ValueError(
+            f"output name '{name}' contains invalid characters "
+            "(must be alphanumeric with underscores, starting with letter or underscore)"
+        )
+
+    # reasonable length limit
+    if len(name) > 128:
+        raise ValueError("output name exceeds maximum length of 128 characters")
+
+    return name
+
+
+def validate_sha(sha: str) -> str:
+    """Validate a git SHA format.
+
+    Args:
+        sha: The SHA to validate.
+
+    Returns:
+        The validated SHA.
+
+    Raises:
+        ValueError: If the SHA format is invalid.
+    """
+    if not sha:
+        raise ValueError("SHA cannot be empty")
+
+    # git SHA must be 40 hex characters (full SHA) or 64 for SHA-256
+    # use \Z instead of $ to reject trailing newlines
+    if not re.match(r"^[a-f0-9]{40}\Z", sha) and not re.match(r"^[a-f0-9]{64}\Z", sha):
+        raise ValueError(f"invalid SHA format: {sha[:20]}..." if len(sha) > 20 else f"invalid SHA format: {sha}")
+
+    return sha
+
+
+def write_output(name: str, value: str) -> None:
+    """Write an output to GITHUB_OUTPUT file.
+
+    Args:
+        name: Output name (must be alphanumeric with underscores).
+        value: Output value.
+
+    Raises:
+        ValueError: If the name is invalid.
+    """
+    # validate and sanitize the name to prevent injection
+    sanitized_name = validate_output_name(name)
+
+    # sanitize value to prevent output injection
+    # remove any characters that could break the output format
+    sanitized_value = re.sub(r"[\r\n]", " ", value)
+
+    output_file = os.environ.get("GITHUB_OUTPUT")
+    if output_file:
+        with open(output_file, "a") as f:  # noqa: PTH123
+            f.write(f"{sanitized_name}={sanitized_value}\n")
+    else:
+        # fallback for local testing
+        print(f"OUTPUT: {sanitized_name}={sanitized_value}")
+
+
+def write_error(message: str) -> None:
+    """Write an error annotation to GitHub Actions.
+
+    Args:
+        message: Error message.
+    """
+    # sanitize message for GitHub Actions annotation format
+    sanitized = re.sub(r"[\r\n]", " ", message)
+    print(f"::error::{sanitized}")
+
+
+def parse_args(args: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments.
+
+    Args:
+        args: Command line arguments (defaults to sys.argv).
+
+    Returns:
+        Parsed arguments.
+    """
+    parser = argparse.ArgumentParser(
+        description="Create and push a git tag using a deploy key",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--tag",
+        required=True,
+        help="The tag to create (e.g., v1.2.3)",
+    )
+    # NOTE: deploy-key is read from INPUT_DEPLOY_KEY environment variable
+    # to avoid exposing the secret in process listings (ps, /proc/*/cmdline)
+    parser.add_argument(
+        "--tag-message",
+        default="",
+        help="Annotated tag message (defaults to 'Release <tag>')",
+    )
+    parser.add_argument(
+        "--git-user-name",
+        default="github-actions[bot]",
+        help="Git user.name for the tag",
+    )
+    parser.add_argument(
+        "--git-user-email",
+        default="github-actions[bot]@users.noreply.github.com",
+        help="Git user.email for the tag",
+    )
+    parser.add_argument(
+        "--repository",
+        required=True,
+        help="Repository in 'owner/repo' format",
+    )
+    return parser.parse_args(args)
+
+
+def main(args: list[str] | None = None, deploy_key: str | None = None) -> int:
+    """Main entry point.
+
+    Args:
+        args: Command line arguments (defaults to sys.argv).
+        deploy_key: Deploy key (defaults to INPUT_DEPLOY_KEY env var).
+
+    Returns:
+        Exit code (0 for success, 1 for failure).
+    """
+    parsed = parse_args(args)
+
+    # read deploy key from environment variable to avoid exposing it in process listings
+    if deploy_key is None:
+        deploy_key = os.environ.get("INPUT_DEPLOY_KEY")
+
+    try:
+        config = validate_config(
+            tag=parsed.tag,
+            deploy_key=deploy_key,
+            tag_message=parsed.tag_message,
+            git_user_name=parsed.git_user_name,
+            git_user_email=parsed.git_user_email,
+            repository=parsed.repository,
+        )
+    except ValidationError as e:
+        write_error(f"Validation failed: {e}")
+        return 1
+
+    try:
+        sha = create_and_push_tag(config)
+    except (ValidationError, GitError) as e:
+        write_error(str(e))
+        return 1
+
+    # validate SHA format before writing to output (defense in depth)
+    try:
+        validated_sha = validate_sha(sha)
+    except ValueError as e:
+        write_error(f"Internal error: {e}")
+        return 1
+
+    write_output("sha", validated_sha)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/actions/create-tag-via-deploy-key/pyproject.toml
+++ b/.github/actions/create-tag-via-deploy-key/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "create-tag-via-deploy-key"
+version = "0.1.0"
+requires-python = ">=3.10"
+
+[tool.ruff]
+line-length = 120
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "S", "B", "UP"]
+# S = bandit security checks
+# B = bugbear
+# UP = pyupgrade
+
+[tool.ruff.lint.per-file-ignores]
+"test_*.py" = [
+    "S101",  # assert usage is expected in tests
+    "S105",  # hardcoded passwords are test fixtures
+    "S106",  # hardcoded passwords are test fixtures
+    "S110",  # try-except-pass is acceptable in tests for ignoring expected failures
+    "S310",  # URL open for permitted schemes is fine in tests (hitting GitHub API)
+    "S603",  # subprocess calls in tests use controlled test fixtures
+    "S607",  # partial executable paths are fine in tests (not security-sensitive)
+]
+
+[tool.pytest.ini_options]
+testpaths = ["."]
+python_files = "test_*.py"

--- a/.github/actions/create-tag-via-deploy-key/test_create_tag.py
+++ b/.github/actions/create-tag-via-deploy-key/test_create_tag.py
@@ -1,0 +1,1700 @@
+"""Tests for create_tag module."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from create_tag import (
+    GITHUB_SSH_KEY_ECDSA,
+    GITHUB_SSH_KEY_ED25519,
+    GITHUB_SSH_KEY_RSA,
+    GITHUB_SSH_KEYS,
+    Config,
+    GitError,
+    SSHConfig,
+    ValidationError,
+    _parse_agent_var,
+    _restore_git_config,
+    create_and_push_tag,
+    get_git_config,
+    get_github_ssh_host_keys,
+    main,
+    parse_args,
+    run_git,
+    set_git_config,
+    setup_ssh_key,
+    tag_exists_locally,
+    tag_exists_remotely,
+    unset_git_config,
+    validate_config,
+    validate_deploy_key,
+    validate_output_name,
+    validate_repository,
+    validate_safe_string,
+    validate_sha,
+    validate_tag,
+    write_error,
+    write_output,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+# module-level fixture for valid SSH key (used by multiple test classes)
+@pytest.fixture
+def valid_ssh_key() -> str:
+    """A valid SSH private key for testing.
+
+    Note: This key has matching BEGIN/END markers as required by the improved
+    validation. It's not a real key, just valid PEM structure for testing.
+    """
+    return "-----BEGIN OPENSSH PRIVATE KEY-----\nbase64encodedkeydata\n-----END OPENSSH PRIVATE KEY-----"
+
+
+class IsolatedGitRepo:
+    """An isolated git repository for testing.
+
+    Creates a temporary directory with a git repo and optional bare "origin" remote.
+    All git operations within the test will use this repo, fully isolated from the
+    user's global git configuration (no gpg signing, no hooks, no global config).
+    """
+
+    def __init__(self, tmp_path: Path, with_origin: bool = False) -> None:
+        self.tmp_path = tmp_path
+        self.repo_path = tmp_path / "repo"
+        self.repo_path.mkdir()
+
+        self.origin_path: Path | None = None
+        if with_origin:
+            self.origin_path = tmp_path / "origin.git"
+
+        # environment that isolates git from global/system config
+        self._env = {
+            **os.environ,
+            "GIT_CONFIG_NOSYSTEM": "1",  # ignore /etc/gitconfig
+            "GIT_CONFIG_GLOBAL": "/dev/null",  # ignore ~/.gitconfig
+            "GIT_AUTHOR_NAME": "Test User",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "Test User",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+        }
+
+    def _run_git(self, args: list[str], **kwargs) -> subprocess.CompletedProcess:
+        """Run git command with isolated environment."""
+        return subprocess.run(
+            ["git", *args],
+            cwd=kwargs.pop("cwd", self.repo_path),
+            capture_output=True,
+            check=True,
+            env=self._env,
+            **kwargs,
+        )
+
+    def setup(self) -> None:
+        """Initialize the git repository."""
+        # initialize the repo
+        self._run_git(["init"])
+
+        # configure user for commits (repo-local config)
+        self._run_git(["config", "user.name", "Test User"])
+        self._run_git(["config", "user.email", "test@example.com"])
+
+        # disable gpg signing for this repo
+        self._run_git(["config", "commit.gpgsign", "false"])
+        self._run_git(["config", "tag.gpgsign", "false"])
+
+        # create an initial commit so HEAD exists
+        readme = self.repo_path / "README.md"
+        readme.write_text("# Test Repo\n")
+        self._run_git(["add", "README.md"])
+        self._run_git(["commit", "-m", "Initial commit"])
+
+        # set up a local bare repo as "origin" if requested.
+        # SAFETY: this creates a bare git repo on the local filesystem (not a real remote).
+        # git remotes can be local paths, not just URLs. When we "push to origin" below,
+        # we're pushing to this local directory - nothing leaves the machine.
+        if self.origin_path:
+            self._run_git(
+                ["init", "--bare", str(self.origin_path)],
+                cwd=self.tmp_path,
+            )
+            # point "origin" to the local bare repo path (e.g., /tmp/pytest-xxx/origin.git)
+            self._run_git(["remote", "add", "origin", str(self.origin_path)])
+            # push to the local bare repo (safe - just copying objects between local directories)
+            self._run_git(["push", "-u", "origin", "HEAD:main"])
+
+
+@pytest.fixture
+def isolated_git_repo(tmp_path: Path) -> Iterator[IsolatedGitRepo]:
+    """Fixture providing an isolated git repository.
+
+    Changes to this directory for the test duration, then restores
+    the original working directory.
+    """
+    repo = IsolatedGitRepo(tmp_path, with_origin=False)
+    repo.setup()
+
+    original_cwd = os.getcwd()
+    os.chdir(repo.repo_path)
+    try:
+        yield repo
+    finally:
+        os.chdir(original_cwd)
+
+
+@pytest.fixture
+def isolated_git_repo_with_origin(tmp_path: Path) -> Iterator[IsolatedGitRepo]:
+    """Fixture providing an isolated git repository with a local 'origin' remote.
+
+    Use this for tests that need to interact with a remote.
+    """
+    repo = IsolatedGitRepo(tmp_path, with_origin=True)
+    repo.setup()
+
+    original_cwd = os.getcwd()
+    os.chdir(repo.repo_path)
+    try:
+        yield repo
+    finally:
+        os.chdir(original_cwd)
+
+
+@pytest.fixture
+def github_output_file(tmp_path: Path) -> Iterator[Path]:
+    """Fixture providing a temporary GITHUB_OUTPUT file with automatic cleanup."""
+    output_file = tmp_path / "github_output.txt"
+    output_file.touch()
+    with patch.dict(os.environ, {"GITHUB_OUTPUT": str(output_file)}):
+        yield output_file
+
+
+class TestValidateTag:
+    """Tests for validate_tag function."""
+
+    @pytest.mark.parametrize(
+        "tag",
+        [
+            "v1.0.0",
+            "v1.2.3",
+            "release-1.0",
+            "1.0.0",
+            "v1.0.0-alpha",
+            "v1.0.0-beta.1",
+            "feature/v1.0.0",
+            "v1.0.0_rc1",
+        ],
+    )
+    def test_valid_tags(self, tag: str):
+        assert validate_tag(tag) == tag
+
+    @pytest.mark.parametrize(
+        "tag,error_contains",
+        [
+            ("", "tag is required"),
+            (None, "tag is required"),
+            ("v1 0 0", "invalid characters"),  # spaces
+            ("-v1.0.0", "Must start with alphanumeric"),  # dash prefix caught by regex
+            ("v1..0", "cannot contain '..'"),
+            ("v1.0.0.lock", "cannot end with '.lock'"),
+            ("v" * 300, "invalid characters"),  # too long
+        ],
+    )
+    def test_invalid_tags(self, tag: str | None, error_contains: str):
+        with pytest.raises(ValidationError) as exc_info:
+            validate_tag(tag)
+        assert error_contains in str(exc_info.value)
+
+
+class TestValidateSafeString:
+    """Tests for validate_safe_string function."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "github-actions[bot]",
+            "user@example.com",
+            "John Doe",
+            "bot_name",
+            "user.name",
+        ],
+    )
+    def test_valid_strings(self, value: str):
+        assert validate_safe_string(value, "field") == value
+
+    @pytest.mark.parametrize(
+        "value,error_contains",
+        [
+            ("", "is required"),
+            (None, "is required"),
+            ("user;rm -rf /", "invalid characters"),
+            ("user$(whoami)", "invalid characters"),
+            ("user`id`", "invalid characters"),
+        ],
+    )
+    def test_invalid_strings(self, value: str | None, error_contains: str):
+        with pytest.raises(ValidationError) as exc_info:
+            validate_safe_string(value, "test_field")
+        assert error_contains in str(exc_info.value)
+
+
+class TestValidateRepository:
+    """Tests for validate_repository function."""
+
+    @pytest.mark.parametrize(
+        "repo",
+        [
+            "owner/repo",
+            "my-org/my-repo",
+            "user123/project_name",
+            "Org.Name/Repo.Name",
+        ],
+    )
+    def test_valid_repos(self, repo: str):
+        assert validate_repository(repo) == repo
+
+    @pytest.mark.parametrize(
+        "repo,error_contains",
+        [
+            ("", "repository is required"),
+            (None, "repository is required"),
+            ("noslash", "owner/repo"),
+            ("too/many/slashes", "owner/repo"),
+            ("/repo", "owner/repo"),
+            ("owner/", "owner/repo"),
+            ("owner;evil/repo", "invalid characters"),
+        ],
+    )
+    def test_invalid_repos(self, repo: str | None, error_contains: str):
+        with pytest.raises(ValidationError) as exc_info:
+            validate_repository(repo)
+        assert error_contains in str(exc_info.value)
+
+
+class TestValidateDeployKey:
+    """Tests for validate_deploy_key function."""
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "-----BEGIN OPENSSH PRIVATE KEY-----\nkey content\n-----END OPENSSH PRIVATE KEY-----",
+            "-----BEGIN RSA PRIVATE KEY-----\nkey content\n-----END RSA PRIVATE KEY-----",
+            "-----BEGIN DSA PRIVATE KEY-----\nkey content\n-----END DSA PRIVATE KEY-----",
+            "-----BEGIN EC PRIVATE KEY-----\nkey content\n-----END EC PRIVATE KEY-----",
+            "-----BEGIN PRIVATE KEY-----\nkey content\n-----END PRIVATE KEY-----",  # PKCS#8
+        ],
+    )
+    def test_valid_keys(self, key: str):
+        assert validate_deploy_key(key) == key
+
+    def test_valid_key_with_whitespace(self):
+        # keys can have leading/trailing whitespace
+        key = "  \n-----BEGIN OPENSSH PRIVATE KEY-----\nkey content\n-----END OPENSSH PRIVATE KEY-----\n  "
+        assert validate_deploy_key(key) == key
+
+    @pytest.mark.parametrize(
+        "key,error_contains",
+        [
+            ("", "deploy_key is required"),
+            (None, "deploy_key is required"),
+            ("not a key", "must start with a valid private key header"),
+            (
+                "-----BEGIN PUBLIC KEY-----\ndata\n-----END PUBLIC KEY-----",
+                "must start with a valid private key header",
+            ),
+            # missing end marker
+            ("-----BEGIN OPENSSH PRIVATE KEY-----\nkey content", "missing or invalid end marker"),
+            # mismatched markers
+            (
+                "-----BEGIN OPENSSH PRIVATE KEY-----\nkey\n-----END RSA PRIVATE KEY-----",
+                "missing or invalid end marker",
+            ),
+        ],
+    )
+    def test_invalid_keys(self, key: str | None, error_contains: str):
+        with pytest.raises(ValidationError) as exc_info:
+            validate_deploy_key(key)
+        assert error_contains in str(exc_info.value)
+
+    def test_rejects_null_bytes(self):
+        """Null bytes in keys could cause truncation issues."""
+        key = "-----BEGIN OPENSSH PRIVATE KEY-----\nkey\x00content\n-----END OPENSSH PRIVATE KEY-----"
+        with pytest.raises(ValidationError) as exc_info:
+            validate_deploy_key(key)
+        assert "null bytes" in str(exc_info.value)
+
+    def test_rejects_oversized_key(self):
+        """Keys over 16KB should be rejected to prevent memory exhaustion."""
+        # 16KB + 1 byte of content (plus headers)
+        large_content = "A" * (16 * 1024 + 1)
+        key = f"-----BEGIN OPENSSH PRIVATE KEY-----\n{large_content}\n-----END OPENSSH PRIVATE KEY-----"
+        with pytest.raises(ValidationError) as exc_info:
+            validate_deploy_key(key)
+        assert "exceeds maximum size" in str(exc_info.value)
+
+    def test_accepts_key_at_size_limit(self):
+        """Keys at exactly 16KB should be accepted."""
+        # calculate how much content we can have within the 16KB limit
+        header = "-----BEGIN OPENSSH PRIVATE KEY-----\n"
+        footer = "\n-----END OPENSSH PRIVATE KEY-----"
+        max_content_size = 16 * 1024 - len(header) - len(footer)
+        content = "A" * max_content_size
+        key = f"{header}{content}{footer}"
+        # should not raise
+        assert validate_deploy_key(key) == key
+
+    def test_rejects_public_key_with_private_in_comment(self):
+        """Prevent bypass where 'PRIVATE KEY' appears in a comment but it's actually a public key."""
+        # this should fail because it doesn't start with a valid private key header
+        key = "-----BEGIN OPENSSH PUBLIC KEY-----\ndata\n# PRIVATE KEY-----\n-----END OPENSSH PUBLIC KEY-----"
+        with pytest.raises(ValidationError) as exc_info:
+            validate_deploy_key(key)
+        assert "must start with a valid private key header" in str(exc_info.value)
+
+
+class TestValidateConfig:
+    """Tests for validate_config function."""
+
+    def test_valid_config(self, valid_ssh_key: str):
+        config = validate_config(
+            tag="v1.0.0",
+            deploy_key=valid_ssh_key,
+            tag_message="Release v1.0.0",
+            git_user_name="bot",
+            git_user_email="bot@example.com",
+            repository="owner/repo",
+        )
+        assert config.tag == "v1.0.0"
+        assert config.tag_message == "Release v1.0.0"
+        assert config.git_user_name == "bot"
+        assert config.git_user_email == "bot@example.com"
+        assert config.repository == "owner/repo"
+
+    def test_default_tag_message(self, valid_ssh_key: str):
+        config = validate_config(
+            tag="v1.0.0",
+            deploy_key=valid_ssh_key,
+            tag_message="",
+            git_user_name="bot",
+            git_user_email="bot@example.com",
+            repository="owner/repo",
+        )
+        assert config.tag_message == "Release v1.0.0"
+
+    def test_fails_fast_on_first_error(self):
+        # validation fails on first error (tag is required)
+        with pytest.raises(ValidationError) as exc_info:
+            validate_config(
+                tag="",
+                deploy_key="",
+                tag_message="",
+                git_user_name="",
+                git_user_email="",
+                repository="",
+            )
+        assert "tag is required" in str(exc_info.value)
+
+    def test_tag_message_with_control_chars(self, valid_ssh_key: str):
+        with pytest.raises(ValidationError) as exc_info:
+            validate_config(
+                tag="v1.0.0",
+                deploy_key=valid_ssh_key,
+                tag_message="message\x00with\x01control",
+                git_user_name="bot",
+                git_user_email="bot@example.com",
+                repository="owner/repo",
+            )
+        assert "control characters" in str(exc_info.value)
+
+    def test_tag_message_exceeds_max_length(self, valid_ssh_key: str):
+        # tag message over 4096 characters should be rejected
+        long_message = "x" * 4097
+        with pytest.raises(ValidationError) as exc_info:
+            validate_config(
+                tag="v1.0.0",
+                deploy_key=valid_ssh_key,
+                tag_message=long_message,
+                git_user_name="bot",
+                git_user_email="bot@example.com",
+                repository="owner/repo",
+            )
+        assert "exceeds maximum length" in str(exc_info.value)
+
+    def test_tag_message_at_max_length_allowed(self, valid_ssh_key: str):
+        # tag message exactly at 4096 characters should be accepted
+        max_length_message = "x" * 4096
+        config = validate_config(
+            tag="v1.0.0",
+            deploy_key=valid_ssh_key,
+            tag_message=max_length_message,
+            git_user_name="bot",
+            git_user_email="bot@example.com",
+            repository="owner/repo",
+        )
+        assert config.tag_message == max_length_message
+
+
+class TestParseAgentVar:
+    """Tests for _parse_agent_var helper function."""
+
+    def test_parses_auth_sock(self, tmp_path: Path):
+        # use tmp_path to construct a realistic path for testing
+        agent_path = str(tmp_path / "ssh-xxxxx" / "agent.12345")
+        output = f"SSH_AUTH_SOCK={agent_path}; export SSH_AUTH_SOCK;\n"
+        result = _parse_agent_var(output, "SSH_AUTH_SOCK")
+        assert result == agent_path
+
+    def test_parses_agent_pid(self):
+        output = "SSH_AGENT_PID=12345; export SSH_AGENT_PID;\n"
+        result = _parse_agent_var(output, "SSH_AGENT_PID")
+        assert result == "12345"
+
+    def test_parses_from_full_output(self, tmp_path: Path):
+        # use tmp_path to construct realistic paths for testing
+        agent_path = str(tmp_path / "ssh-abc" / "agent.999")
+        output = (
+            f"SSH_AUTH_SOCK={agent_path}; export SSH_AUTH_SOCK;\n"
+            "SSH_AGENT_PID=999; export SSH_AGENT_PID;\n"
+            "echo Agent pid 999;\n"
+        )
+        assert _parse_agent_var(output, "SSH_AUTH_SOCK") == agent_path
+        assert _parse_agent_var(output, "SSH_AGENT_PID") == "999"
+
+    def test_raises_on_missing_var(self):
+        output = "SSH_AUTH_SOCK=/tmp/ssh-abc/agent.123; export SSH_AUTH_SOCK;\n"
+        with pytest.raises(RuntimeError) as exc_info:
+            _parse_agent_var(output, "SSH_AGENT_PID")
+        assert "failed to parse SSH_AGENT_PID" in str(exc_info.value)
+
+    def test_raises_on_empty_output(self):
+        with pytest.raises(RuntimeError) as exc_info:
+            _parse_agent_var("", "SSH_AUTH_SOCK")
+        assert "failed to parse SSH_AUTH_SOCK" in str(exc_info.value)
+
+
+class TestSetupSshKey:
+    """Tests for setup_ssh_key context manager."""
+
+    def test_returns_ssh_config_named_tuple(self):
+        """Verify SSHConfig is returned with correct attributes (mocked ssh-agent)."""
+        mock_agent_output = (
+            "SSH_AUTH_SOCK=/tmp/ssh-mock/agent.12345; export SSH_AUTH_SOCK;\n"
+            "SSH_AGENT_PID=12345; export SSH_AGENT_PID;\n"
+        )
+
+        with (
+            patch("subprocess.run") as mock_run,
+            patch("os.kill") as mock_kill,
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=mock_agent_output,
+                stderr="",
+            )
+
+            test_key = "-----BEGIN TEST-----\ntest content\n-----END TEST-----"
+            with setup_ssh_key(test_key) as ssh_config:
+                assert isinstance(ssh_config, SSHConfig)
+                assert hasattr(ssh_config, "auth_sock")
+                assert hasattr(ssh_config, "agent_pid")
+                assert hasattr(ssh_config, "known_hosts_path")
+
+            # verify agent was killed on exit
+            mock_kill.assert_called_once()
+
+    def test_key_not_written_to_disk(self):
+        """Verify no key file is created - key is loaded into ssh-agent via stdin."""
+        mock_agent_output = (
+            "SSH_AUTH_SOCK=/tmp/ssh-mock/agent.12345; export SSH_AUTH_SOCK;\n"
+            "SSH_AGENT_PID=12345; export SSH_AGENT_PID;\n"
+        )
+
+        with (
+            patch("subprocess.run") as mock_run,
+            patch("os.kill"),
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=mock_agent_output,
+                stderr="",
+            )
+
+            test_key = "-----BEGIN TEST-----\ntest content\n-----END TEST-----"
+            with setup_ssh_key(test_key) as ssh_config:
+                # verify no "deploy_key" file exists in the temp directory
+                tmpdir = Path(ssh_config.known_hosts_path).parent
+                key_file = tmpdir / "deploy_key"
+                assert not key_file.exists(), "Key should not be written to disk"
+
+                # verify only known_hosts exists
+                files = list(tmpdir.iterdir())
+                assert len(files) == 1
+                assert files[0].name == "known_hosts"
+
+    def test_ssh_add_receives_key_via_stdin(self, tmp_path: Path):
+        """Verify ssh-add is called with the key provided via stdin."""
+        agent_path = str(tmp_path / "ssh-mock" / "agent.12345")
+        mock_agent_output = (
+            f"SSH_AUTH_SOCK={agent_path}; export SSH_AUTH_SOCK;\nSSH_AGENT_PID=12345; export SSH_AGENT_PID;\n"
+        )
+
+        calls: list[tuple] = []
+
+        def capture_run(*args, **kwargs):
+            calls.append((args, kwargs))
+            return MagicMock(returncode=0, stdout=mock_agent_output, stderr="")
+
+        with (
+            patch("subprocess.run", side_effect=capture_run),
+            patch("os.kill"),
+        ):
+            test_key = "-----BEGIN TEST-----\ntest content\n-----END TEST-----"
+            with setup_ssh_key(test_key):
+                pass
+
+        # find the ssh-add call (check if executable path ends with "ssh-add")
+        ssh_add_call = None
+        for call_args, call_kwargs in calls:
+            if call_args and call_args[0] and call_args[0][0].endswith("ssh-add"):
+                ssh_add_call = (call_args, call_kwargs)
+                break
+
+        assert ssh_add_call is not None, "ssh-add should be called"
+        _, ssh_add_kwargs = ssh_add_call
+        assert ssh_add_kwargs.get("input") == test_key, "Key should be passed via stdin"
+
+    def test_known_hosts_written_with_github_keys(self):
+        """Verify known_hosts is written with GitHub's SSH host keys."""
+        mock_agent_output = (
+            "SSH_AUTH_SOCK=/tmp/ssh-mock/agent.12345; export SSH_AUTH_SOCK;\n"
+            "SSH_AGENT_PID=12345; export SSH_AGENT_PID;\n"
+        )
+
+        with (
+            patch("subprocess.run") as mock_run,
+            patch("os.kill"),
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=mock_agent_output,
+                stderr="",
+            )
+
+            test_key = "-----BEGIN TEST-----\ntest content\n-----END TEST-----"
+            with setup_ssh_key(test_key) as ssh_config:
+                known_hosts_path = Path(ssh_config.known_hosts_path)
+
+                # verify known_hosts exists
+                assert known_hosts_path.exists()
+
+                # verify it contains GitHub's SSH host keys
+                content = known_hosts_path.read_text()
+                assert "github.com" in content
+                assert "ssh-ed25519" in content
+                assert "ssh-rsa" in content
+                assert "ecdsa-sha2-nistp256" in content
+
+                # verify permissions are restrictive (600)
+                mode = known_hosts_path.stat().st_mode
+                assert mode & stat.S_IRWXU == stat.S_IRUSR | stat.S_IWUSR
+                assert mode & stat.S_IRWXG == 0
+                assert mode & stat.S_IRWXO == 0
+
+    def test_agent_killed_on_normal_exit(self):
+        """Verify ssh-agent process is terminated on context exit."""
+        mock_agent_output = (
+            "SSH_AUTH_SOCK=/tmp/ssh-mock/agent.12345; export SSH_AUTH_SOCK;\n"
+            "SSH_AGENT_PID=12345; export SSH_AGENT_PID;\n"
+        )
+
+        with (
+            patch("subprocess.run") as mock_run,
+            patch("os.kill") as mock_kill,
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=mock_agent_output,
+                stderr="",
+            )
+
+            test_key = "-----BEGIN TEST-----\ntest\n-----END TEST-----"
+            with setup_ssh_key(test_key) as ssh_config:
+                assert ssh_config.agent_pid == 12345
+
+            # verify SIGTERM was sent to the agent
+            import signal
+
+            mock_kill.assert_called_once_with(12345, signal.SIGTERM)
+
+    def test_agent_killed_on_exception(self):
+        """Verify ssh-agent is terminated even when an exception occurs."""
+        mock_agent_output = (
+            "SSH_AUTH_SOCK=/tmp/ssh-mock/agent.99999; export SSH_AUTH_SOCK;\n"
+            "SSH_AGENT_PID=99999; export SSH_AGENT_PID;\n"
+        )
+
+        with (
+            patch("subprocess.run") as mock_run,
+            patch("os.kill") as mock_kill,
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=mock_agent_output,
+                stderr="",
+            )
+
+            test_key = "-----BEGIN TEST-----\ntest\n-----END TEST-----"
+            with pytest.raises(RuntimeError):
+                with setup_ssh_key(test_key):
+                    raise RuntimeError("test exception")
+
+            # verify agent was still killed
+            import signal
+
+            mock_kill.assert_called_once_with(99999, signal.SIGTERM)
+
+    def test_known_hosts_cleanup_on_exit(self):
+        """Verify temp directory with known_hosts is cleaned up."""
+        mock_agent_output = (
+            "SSH_AUTH_SOCK=/tmp/ssh-mock/agent.12345; export SSH_AUTH_SOCK;\n"
+            "SSH_AGENT_PID=12345; export SSH_AGENT_PID;\n"
+        )
+        saved_path = None
+
+        with (
+            patch("subprocess.run") as mock_run,
+            patch("os.kill"),
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=mock_agent_output,
+                stderr="",
+            )
+
+            test_key = "-----BEGIN TEST-----\ntest\n-----END TEST-----"
+            with setup_ssh_key(test_key) as ssh_config:
+                saved_path = ssh_config.known_hosts_path
+                assert Path(saved_path).exists()
+
+        # after context exit, known_hosts should be cleaned up
+        assert not Path(saved_path).exists()
+
+    def test_handles_agent_already_exited(self):
+        """Verify no error if agent has already exited when trying to kill it."""
+        mock_agent_output = (
+            "SSH_AUTH_SOCK=/tmp/ssh-mock/agent.12345; export SSH_AUTH_SOCK;\n"
+            "SSH_AGENT_PID=12345; export SSH_AGENT_PID;\n"
+        )
+
+        with (
+            patch("subprocess.run") as mock_run,
+            patch("os.kill", side_effect=OSError("No such process")),
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=mock_agent_output,
+                stderr="",
+            )
+
+            test_key = "-----BEGIN TEST-----\ntest\n-----END TEST-----"
+            # should not raise even though kill fails
+            with setup_ssh_key(test_key):
+                pass
+
+
+class TestRunGit:
+    """Tests for run_git function."""
+
+    def test_successful_command(self, isolated_git_repo: IsolatedGitRepo):
+        result = run_git(["--version"])
+        assert "git version" in result.stdout
+
+    def test_failed_command(self, isolated_git_repo: IsolatedGitRepo):
+        with pytest.raises(GitError) as exc_info:
+            run_git(["rev-parse", "nonexistent-ref-12345"])
+        assert "rev-parse failed" in str(exc_info.value)
+
+    def test_env_passed_to_command(self, isolated_git_repo: IsolatedGitRepo):
+        # git config --get will fail if not set, but we can verify env handling works
+        result = run_git(["config", "--list"], env={"GIT_CONFIG_NOSYSTEM": "1"})
+        # should succeed without system config
+        assert result.returncode == 0
+
+
+class TestTagExistsLocally:
+    """Tests for tag_exists_locally function."""
+
+    def test_nonexistent_tag(self, isolated_git_repo: IsolatedGitRepo):
+        assert tag_exists_locally("definitely-not-a-real-tag-12345") is False
+
+    def test_existing_tag(self, isolated_git_repo: IsolatedGitRepo):
+        # create a lightweight tag (--no-sign to bypass any gpgsign config)
+        subprocess.run(
+            ["git", "-c", "tag.gpgsign=false", "tag", "v1.0.0"],
+            check=True,
+            capture_output=True,
+        )
+        assert tag_exists_locally("v1.0.0") is True
+
+    def test_does_not_match_partial(self, isolated_git_repo: IsolatedGitRepo):
+        # create v1.0.0, then check that v1.0 doesn't falsely match
+        subprocess.run(
+            ["git", "-c", "tag.gpgsign=false", "tag", "v1.0.0"],
+            check=True,
+            capture_output=True,
+        )
+        assert tag_exists_locally("v1.0") is False
+
+
+class TestTagExistsRemotely:
+    """Tests for tag_exists_remotely function."""
+
+    def test_nonexistent_tag(self, isolated_git_repo_with_origin: IsolatedGitRepo):
+        result = tag_exists_remotely("definitely-not-a-real-tag-12345")
+        assert result is False
+
+    def test_existing_tag(self, isolated_git_repo_with_origin: IsolatedGitRepo):
+        # create and push a lightweight tag to the local "origin"
+        subprocess.run(
+            ["git", "-c", "tag.gpgsign=false", "tag", "v1.0.0"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(["git", "push", "origin", "v1.0.0"], check=True, capture_output=True)
+        assert tag_exists_remotely("v1.0.0") is True
+
+    def test_does_not_match_partial(self, isolated_git_repo_with_origin: IsolatedGitRepo):
+        # create v1.0.0, check that v1.0 doesn't falsely match
+        subprocess.run(
+            ["git", "-c", "tag.gpgsign=false", "tag", "v1.0.0"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(["git", "push", "origin", "v1.0.0"], check=True, capture_output=True)
+        assert tag_exists_remotely("v1.0") is False
+
+
+class TestWriteOutput:
+    """Tests for write_output function."""
+
+    def test_writes_to_github_output(self, github_output_file: Path):
+        write_output("test_name", "test_value")
+        assert github_output_file.read_text() == "test_name=test_value\n"
+
+    def test_sanitizes_newlines(self, github_output_file: Path):
+        write_output("name", "value\nwith\nnewlines")
+        content = github_output_file.read_text()
+        assert "\n" not in content.split("=", 1)[1].rstrip("\n")
+        assert "value with newlines" in content
+
+    def test_fallback_when_no_github_output(self, capsys):
+        with patch.dict(os.environ, {}, clear=False):
+            # remove GITHUB_OUTPUT if present
+            os.environ.pop("GITHUB_OUTPUT", None)
+            write_output("name", "value")
+
+        captured = capsys.readouterr()
+        assert "OUTPUT: name=value" in captured.out
+
+
+class TestWriteError:
+    """Tests for write_error function."""
+
+    def test_writes_error_annotation(self, capsys):
+        write_error("Something went wrong")
+        captured = capsys.readouterr()
+        assert "::error::Something went wrong" in captured.out
+
+    def test_sanitizes_newlines(self, capsys):
+        write_error("Error on\nmultiple\nlines")
+        captured = capsys.readouterr()
+        # newlines should be replaced with spaces
+        assert "::error::Error on multiple lines" in captured.out
+        assert "\n" not in captured.out.split("::error::")[1].rstrip("\n")
+
+
+class TestParseArgs:
+    """Tests for parse_args function."""
+
+    def test_required_args(self):
+        args = parse_args(["--tag", "v1.0.0", "--repository", "owner/repo"])
+        assert args.tag == "v1.0.0"
+        assert args.repository == "owner/repo"
+
+    def test_default_values(self):
+        args = parse_args(["--tag", "v1.0.0", "--repository", "owner/repo"])
+        assert args.tag_message == ""
+        assert args.git_user_name == "github-actions[bot]"
+        assert args.git_user_email == "github-actions[bot]@users.noreply.github.com"
+
+    def test_custom_values(self):
+        args = parse_args(
+            [
+                "--tag",
+                "v2.0.0",
+                "--repository",
+                "org/project",
+                "--tag-message",
+                "Custom release",
+                "--git-user-name",
+                "bot",
+                "--git-user-email",
+                "bot@test.com",
+            ]
+        )
+        assert args.tag == "v2.0.0"
+        assert args.repository == "org/project"
+        assert args.tag_message == "Custom release"
+        assert args.git_user_name == "bot"
+        assert args.git_user_email == "bot@test.com"
+
+    def test_missing_required_tag(self):
+        with pytest.raises(SystemExit):
+            parse_args(["--repository", "owner/repo"])
+
+    def test_missing_required_repository(self):
+        with pytest.raises(SystemExit):
+            parse_args(["--tag", "v1.0.0"])
+
+
+class TestTagExistsRemotelyExactMatch:
+    """Tests for tag_exists_remotely exact matching behavior."""
+
+    def test_exact_match_required(self):
+        # mock the run_git to return a response that would cause substring matching issues
+        with patch("create_tag.run_git") as mock_run_git:
+            # simulate ls-remote output for v1.0.0 when searching for v1.0
+            mock_result = MagicMock()
+            mock_result.stdout = "abc123\trefs/tags/v1.0.0\n"
+            mock_run_git.return_value = mock_result
+
+            # searching for v1.0 should NOT match v1.0.0
+            result = tag_exists_remotely("v1.0")
+            assert result is False
+
+    def test_finds_exact_tag(self):
+        with patch("create_tag.run_git") as mock_run_git:
+            mock_result = MagicMock()
+            mock_result.stdout = "abc123\trefs/tags/v1.0.0\n"
+            mock_run_git.return_value = mock_result
+
+            result = tag_exists_remotely("v1.0.0")
+            assert result is True
+
+    def test_empty_output(self):
+        with patch("create_tag.run_git") as mock_run_git:
+            mock_result = MagicMock()
+            mock_result.stdout = ""
+            mock_run_git.return_value = mock_result
+
+            result = tag_exists_remotely("v1.0.0")
+            assert result is False
+
+    def test_git_error_returns_false(self):
+        with patch("create_tag.run_git") as mock_run_git:
+            mock_run_git.side_effect = GitError("remote not found")
+
+            result = tag_exists_remotely("v1.0.0")
+            assert result is False
+
+
+class TestMain:
+    """Tests for main function."""
+
+    def test_validation_error_returns_1(self, capsys):
+        result = main(
+            args=["--tag", "", "--repository", "owner/repo"],
+            deploy_key="invalid",
+        )
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "::error::" in captured.out
+
+    def test_missing_deploy_key_returns_1(self, capsys):
+        # ensure INPUT_DEPLOY_KEY is not set
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("INPUT_DEPLOY_KEY", None)
+            result = main(args=["--tag", "v1.0.0", "--repository", "owner/repo"])
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "deploy_key is required" in captured.out
+
+    def test_reads_deploy_key_from_env(self, valid_ssh_key: str):
+        with (
+            patch.dict(os.environ, {"INPUT_DEPLOY_KEY": valid_ssh_key}),
+            patch("create_tag.create_and_push_tag") as mock_create,
+            patch("create_tag.write_output"),
+        ):
+            mock_create.return_value = "a" * 40  # valid SHA-1 format
+            result = main(args=["--tag", "v1.0.0", "--repository", "owner/repo"])
+
+        assert result == 0
+        # verify the config was created with the key from env
+        call_args = mock_create.call_args[0][0]
+        assert call_args.deploy_key == valid_ssh_key
+
+    def test_success_writes_sha_output(self, valid_ssh_key: str, github_output_file: Path):
+        valid_sha = "a1b2c3d4e5f6" + "0" * 28  # 40 hex characters
+        with patch("create_tag.create_and_push_tag") as mock_create:
+            mock_create.return_value = valid_sha
+            result = main(
+                args=["--tag", "v1.0.0", "--repository", "owner/repo"],
+                deploy_key=valid_ssh_key,
+            )
+
+        assert result == 0
+        assert f"sha={valid_sha}" in github_output_file.read_text()
+
+    def test_git_error_returns_1(self, valid_ssh_key: str, capsys):
+        with patch("create_tag.create_and_push_tag") as mock_create:
+            mock_create.side_effect = GitError("push failed")
+            result = main(
+                args=["--tag", "v1.0.0", "--repository", "owner/repo"],
+                deploy_key=valid_ssh_key,
+            )
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "::error::push failed" in captured.out
+
+
+class TestCreateAndPushTag:
+    """Tests for create_and_push_tag function.
+
+    These tests use an isolated git repository to avoid modifying the user's
+    actual git configuration. The isolated repo provides a safe environment
+    for testing git operations.
+    """
+
+    @pytest.fixture
+    def valid_config(self, isolated_git_repo_with_origin: IsolatedGitRepo) -> Config:
+        """Config that uses the isolated repo's origin path."""
+        # we use the local origin path but the function will try to use SSH
+        # so we still need to mock the push operation
+        # note: key has matching BEGIN/END markers as required by improved validation
+        return Config(
+            tag="v1.0.0",
+            deploy_key="-----BEGIN OPENSSH PRIVATE KEY-----\nbase64data\n-----END OPENSSH PRIVATE KEY-----",
+            tag_message="Release v1.0.0",
+            git_user_name="bot",
+            git_user_email="bot@example.com",
+            repository="owner/repo",
+        )
+
+    @pytest.fixture
+    def mock_setup_ssh_key(self, tmp_path: Path):
+        """Fixture providing a mocked setup_ssh_key context manager."""
+        # create a real known_hosts file for the mock
+        known_hosts = tmp_path / "known_hosts"
+        known_hosts.write_text("github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5...\n")
+
+        # create mock agent socket path using tmp_path
+        mock_agent_sock = str(tmp_path / "mock-ssh-agent" / "agent.12345")
+
+        @contextmanager
+        def _mock_setup_ssh_key(deploy_key: str):  # noqa: ARG001
+            yield SSHConfig(
+                auth_sock=mock_agent_sock,
+                agent_pid=12345,
+                known_hosts_path=str(known_hosts),
+            )
+
+        return _mock_setup_ssh_key
+
+    def test_tag_already_exists_locally(
+        self,
+        isolated_git_repo_with_origin: IsolatedGitRepo,
+        valid_config: Config,
+        mock_setup_ssh_key,
+    ):
+        """Test that existing local tag raises ValidationError."""
+        # create a lightweight tag locally first (bypass gpgsign config)
+        subprocess.run(
+            ["git", "-c", "tag.gpgsign=false", "tag", "v1.0.0"],
+            check=True,
+            capture_output=True,
+        )
+
+        with patch("create_tag.setup_ssh_key", mock_setup_ssh_key):
+            with pytest.raises(ValidationError) as exc_info:
+                create_and_push_tag(valid_config)
+            assert "already exists locally" in str(exc_info.value)
+
+        # verify that the repo's origin URL was restored (not changed to owner/repo)
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert str(isolated_git_repo_with_origin.origin_path) in result.stdout
+
+    def test_tag_already_exists_remotely(
+        self,
+        isolated_git_repo_with_origin: IsolatedGitRepo,
+        valid_config: Config,
+        mock_setup_ssh_key,
+    ):
+        """Test that existing remote tag raises ValidationError.
+
+        Note: create_and_push_tag changes the remote URL to SSH before checking
+        if the tag exists remotely. Since we can't actually have a tag on the
+        SSH remote in tests, we mock tag_exists_remotely to return True.
+        """
+        with (
+            patch("create_tag.setup_ssh_key", mock_setup_ssh_key),
+            patch("create_tag.tag_exists_remotely", return_value=True),
+        ):
+            with pytest.raises(ValidationError) as exc_info:
+                create_and_push_tag(valid_config)
+            assert "already exists on remote" in str(exc_info.value)
+
+        # verify that the repo's origin URL was restored
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert str(isolated_git_repo_with_origin.origin_path) in result.stdout
+
+    def test_restores_config_on_success(self, isolated_git_repo_with_origin: IsolatedGitRepo, mock_setup_ssh_key):
+        """Test that git config is restored after successful tag creation.
+
+        This test intercepts only the 'push' command since we can't use SSH
+        in a test environment. All other git operations run for real.
+        """
+        config = Config(
+            tag="v2.0.0",
+            deploy_key="-----BEGIN OPENSSH PRIVATE KEY-----\nbase64data\n-----END OPENSSH PRIVATE KEY-----",
+            tag_message="Release v2.0.0",
+            git_user_name="bot",
+            git_user_email="bot@example.com",
+            repository="owner/repo",
+        )
+
+        original_url = get_git_config("remote.origin.url")
+        original_user = get_git_config("user.name")
+        original_email = get_git_config("user.email")
+        original_ssh_cmd = get_git_config("core.sshCommand")
+
+        # save the real run_git function
+        real_run_git = run_git
+
+        def mock_run_git_selective(args: list[str], env: dict[str, str] | None = None):
+            """Mock that only intercepts push commands, passes through everything else."""
+            if args[0] == "push":
+                # return a successful mock for push
+                return MagicMock(returncode=0, stdout="", stderr="")
+            # for all other commands, call the real function
+            return real_run_git(args, env)
+
+        with (
+            patch("create_tag.setup_ssh_key", mock_setup_ssh_key),
+            patch("create_tag.run_git", side_effect=mock_run_git_selective),
+        ):
+            create_and_push_tag(config)
+
+        # verify config was restored
+        assert get_git_config("remote.origin.url") == original_url
+        assert get_git_config("user.name") == original_user
+        assert get_git_config("user.email") == original_email
+        assert get_git_config("core.sshCommand") == original_ssh_cmd
+
+    def test_restores_config_on_failure(self, isolated_git_repo_with_origin: IsolatedGitRepo, mock_setup_ssh_key):
+        """Test that git config is restored even when tag creation fails."""
+        config = Config(
+            tag="v3.0.0",
+            deploy_key="-----BEGIN OPENSSH PRIVATE KEY-----\nbase64data\n-----END OPENSSH PRIVATE KEY-----",
+            tag_message="Release v3.0.0",
+            git_user_name="bot",
+            git_user_email="bot@example.com",
+            repository="owner/repo",
+        )
+
+        # create a lightweight tag first so it will fail (bypass gpgsign config)
+        subprocess.run(
+            ["git", "-c", "tag.gpgsign=false", "tag", "v3.0.0"],
+            check=True,
+            capture_output=True,
+        )
+
+        original_url = get_git_config("remote.origin.url")
+        original_user = get_git_config("user.name")
+        original_email = get_git_config("user.email")
+
+        with patch("create_tag.setup_ssh_key", mock_setup_ssh_key):
+            with pytest.raises(ValidationError):
+                create_and_push_tag(config)
+
+        # verify config was restored even after failure
+        assert get_git_config("remote.origin.url") == original_url
+        assert get_git_config("user.name") == original_user
+        assert get_git_config("user.email") == original_email
+
+
+class TestGitConfigHelpers:
+    """Tests for git config helper functions."""
+
+    def test_get_git_config_returns_value(self):
+        # test with a config that should exist in most git repos
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="test-value\n")
+            result = get_git_config("test.key")
+            assert result == "test-value"
+
+    def test_get_git_config_returns_none_when_not_set(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="")
+            result = get_git_config("nonexistent.key")
+            assert result is None
+
+    def test_get_git_config_returns_none_on_error(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = OSError("git not found")
+            result = get_git_config("any.key")
+            assert result is None
+
+    def test_set_git_config_calls_run_git(self):
+        with patch("create_tag.run_git") as mock_run:
+            set_git_config("test.key", "test-value")
+            mock_run.assert_called_once_with(["config", "test.key", "test-value"])
+
+    def test_unset_git_config_does_not_raise(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=5)  # git returns 5 if key not found
+            # should not raise
+            unset_git_config("nonexistent.key")
+
+    def test_unset_git_config_handles_os_error(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = OSError("git not found")
+            # should not raise
+            unset_git_config("any.key")
+
+    def test_restore_git_config_unsets_when_none(self):
+        with patch("create_tag.unset_git_config") as mock_unset:
+            _restore_git_config("test.key", None)
+            mock_unset.assert_called_once_with("test.key")
+
+    def test_restore_git_config_sets_when_value(self):
+        with patch("create_tag.set_git_config") as mock_set:
+            _restore_git_config("test.key", "original-value")
+            mock_set.assert_called_once_with("test.key", "original-value")
+
+
+class TestSecurityFeatures:
+    """Tests for security-related features."""
+
+    def test_github_ssh_keys_tuple_contains_all_key_types(self):
+        # verify the tuple contains all three key types
+        assert len(GITHUB_SSH_KEYS) == 3
+        assert GITHUB_SSH_KEY_ED25519 in GITHUB_SSH_KEYS
+        assert GITHUB_SSH_KEY_ECDSA in GITHUB_SSH_KEYS
+        assert GITHUB_SSH_KEY_RSA in GITHUB_SSH_KEYS
+
+    def test_github_ssh_keys_have_correct_prefixes(self):
+        # verify each key has the expected algorithm prefix
+        assert GITHUB_SSH_KEY_ED25519.startswith("ssh-ed25519 ")
+        assert GITHUB_SSH_KEY_ECDSA.startswith("ecdsa-sha2-nistp256 ")
+        assert GITHUB_SSH_KEY_RSA.startswith("ssh-rsa ")
+
+    def test_get_github_ssh_host_keys_formats_correctly(self):
+        # verify the function generates proper known_hosts format
+        host_keys = get_github_ssh_host_keys()
+        lines = host_keys.strip().split("\n")
+
+        assert len(lines) == 3
+        for line in lines:
+            assert line.startswith("github.com ")
+
+        # verify all key types are present
+        assert "ssh-ed25519" in host_keys
+        assert "ssh-rsa" in host_keys
+        assert "ecdsa-sha2-nistp256" in host_keys
+
+    def test_ssh_command_uses_strict_host_checking(self, tmp_path: Path):
+        """Verify SSH command uses StrictHostKeyChecking=yes with pre-populated known_hosts."""
+        valid_config = Config(
+            tag="v1.0.0",
+            deploy_key="-----BEGIN OPENSSH PRIVATE KEY-----\nbase64data\n-----END OPENSSH PRIVATE KEY-----",
+            tag_message="Release v1.0.0",
+            git_user_name="bot",
+            git_user_email="bot@example.com",
+            repository="owner/repo",
+        )
+
+        ssh_command_captured = None
+
+        def capture_set_config(key: str, value: str) -> None:
+            nonlocal ssh_command_captured
+            if key == "core.sshCommand":
+                ssh_command_captured = value
+
+        # create a mock setup_ssh_key that yields a fake SSHConfig
+        known_hosts = tmp_path / "known_hosts"
+        known_hosts.write_text("github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5...\n")
+        mock_agent_sock = str(tmp_path / "mock-ssh-agent" / "agent.12345")
+
+        @contextmanager
+        def mock_setup_ssh_key(deploy_key: str):  # noqa: ARG001
+            yield SSHConfig(
+                auth_sock=mock_agent_sock,
+                agent_pid=12345,
+                known_hosts_path=str(known_hosts),
+            )
+
+        with (
+            patch("create_tag.setup_ssh_key", mock_setup_ssh_key),
+            patch("create_tag.get_git_config", return_value=None),
+            patch("create_tag.set_git_config", side_effect=capture_set_config),
+            patch("create_tag.run_git") as mock_run,
+            patch("create_tag.tag_exists_locally", return_value=False),
+            patch("create_tag.tag_exists_remotely", return_value=False),
+        ):
+            mock_run.return_value = MagicMock(stdout="abc123\n")
+            # the function will fail at push since we're mocking run_git,
+            # but we capture the SSH command before that happens
+            try:
+                create_and_push_tag(valid_config)
+            except (GitError, ValidationError, AttributeError):
+                pass  # expected - mocked environment won't fully work
+
+        # verify the SSH command was constructed securely
+        assert ssh_command_captured is not None
+        assert "StrictHostKeyChecking=yes" in ssh_command_captured
+        assert "StrictHostKeyChecking=accept-new" not in ssh_command_captured
+        assert "UserKnownHostsFile=" in ssh_command_captured
+        assert "BatchMode=yes" in ssh_command_captured
+        # verify we're using IdentityAgent (ssh-agent) instead of -i (file)
+        assert "IdentityAgent=" in ssh_command_captured
+        assert "-i " not in ssh_command_captured
+
+    def test_ssh_command_paths_are_quoted(self, tmp_path: Path):
+        """Verify paths in SSH command are properly quoted with shlex.quote."""
+        valid_config = Config(
+            tag="v1.0.0",
+            deploy_key="-----BEGIN OPENSSH PRIVATE KEY-----\nbase64data\n-----END OPENSSH PRIVATE KEY-----",
+            tag_message="Release v1.0.0",
+            git_user_name="bot",
+            git_user_email="bot@example.com",
+            repository="owner/repo",
+        )
+
+        ssh_command_captured = None
+
+        def capture_set_config(key: str, value: str) -> None:
+            nonlocal ssh_command_captured
+            if key == "core.sshCommand":
+                ssh_command_captured = value
+
+        # create a mock setup_ssh_key that yields a fake SSHConfig
+        known_hosts = tmp_path / "known_hosts"
+        known_hosts.write_text("github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5...\n")
+        mock_agent_sock = str(tmp_path / "mock-ssh-agent" / "agent.12345")
+
+        @contextmanager
+        def mock_setup_ssh_key(deploy_key: str):  # noqa: ARG001
+            yield SSHConfig(
+                auth_sock=mock_agent_sock,
+                agent_pid=12345,
+                known_hosts_path=str(known_hosts),
+            )
+
+        with (
+            patch("create_tag.setup_ssh_key", mock_setup_ssh_key),
+            patch("create_tag.get_git_config", return_value=None),
+            patch("create_tag.set_git_config", side_effect=capture_set_config),
+            patch("create_tag.run_git") as mock_run,
+            patch("create_tag.tag_exists_locally", return_value=False),
+            patch("create_tag.tag_exists_remotely", return_value=False),
+        ):
+            mock_run.return_value = MagicMock(stdout="abc123\n")
+            try:
+                create_and_push_tag(valid_config)
+            except (GitError, ValidationError, AttributeError):
+                pass  # expected - mocked environment won't fully work
+
+        # the paths should be quoted - verify by checking that the command
+        # contains properly quoted paths (shlex.quote adds quotes when needed)
+        assert ssh_command_captured is not None
+        # paths from tempfile typically don't need quoting, but verify the pattern
+        # is consistent with shlex.quote output (no unquoted special chars)
+        assert "-o IdentityAgent=" in ssh_command_captured
+        assert "-o UserKnownHostsFile=" in ssh_command_captured
+
+
+class TestGitHubSSHKeysAPIValidation:
+    """Tests that validate baked-in SSH keys against GitHub's API.
+
+    These tests hit the live GitHub API to ensure our hardcoded SSH keys
+    are still valid. If GitHub rotates their keys, these tests will fail
+    and the keys in create_tag.py must be updated.
+
+    API documentation: https://docs.github.com/en/rest/meta/meta#get-github-meta-information
+    """
+
+    @pytest.fixture
+    def github_api_keys(self) -> set[str]:
+        """Fetch current SSH keys from GitHub's /meta API endpoint.
+
+        Returns:
+            Set of SSH public keys as returned by the API.
+
+        Raises:
+            pytest.skip: If the API is unreachable (allows offline testing).
+        """
+        import json
+        import urllib.error
+        import urllib.request
+
+        url = "https://api.github.com/meta"
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "User-Agent": "create-tag-via-deploy-key-tests",
+            },
+        )
+
+        try:
+            with urllib.request.urlopen(request, timeout=10) as response:
+                data = json.loads(response.read().decode("utf-8"))
+                return set(data.get("ssh_keys", []))
+        except urllib.error.URLError as e:
+            pytest.skip(f"GitHub API unreachable (offline mode): {e}")
+        except json.JSONDecodeError as e:
+            pytest.fail(f"GitHub API returned invalid JSON: {e}")
+
+    def test_baked_in_keys_match_github_api(self, github_api_keys: set[str]):
+        """Verify baked-in SSH keys exactly match GitHub's API response.
+
+        This test ensures our hardcoded keys are in sync with GitHub.
+        If this test fails, update the GITHUB_SSH_KEY_* constants in create_tag.py
+        with the current keys from the GitHub API.
+
+        To get the current keys, run:
+            curl -s https://api.github.com/meta | jq -r '.ssh_keys[]'
+        """
+        baked_in_keys = set(GITHUB_SSH_KEYS)
+
+        # use symmetric difference to catch both missing and extra keys
+        difference = baked_in_keys.symmetric_difference(github_api_keys)
+        if difference:
+            missing_from_api = baked_in_keys - github_api_keys
+            new_in_api = github_api_keys - baked_in_keys
+
+            message_parts = ["SSH keys mismatch between baked-in and GitHub API!\n"]
+            if missing_from_api:
+                message_parts.append(f"Keys in code but NOT in GitHub API (rotated?):\n{missing_from_api}\n")
+            if new_in_api:
+                message_parts.append(f"Keys in GitHub API but NOT in code (new keys?):\n{new_in_api}\n")
+            message_parts.append(f"\nCurrent GitHub API keys:\n{github_api_keys}\n")
+            message_parts.append("Update GITHUB_SSH_KEY_* constants in create_tag.py")
+
+            pytest.fail("\n".join(message_parts))
+
+
+class TestValidateOutputName:
+    """Tests for validate_output_name function."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "sha",
+            "result",
+            "my_output",
+            "_private",
+            "Output123",
+            "a",
+        ],
+    )
+    def test_valid_names(self, name: str):
+        assert validate_output_name(name) == name
+
+    @pytest.mark.parametrize(
+        "name,error_contains",
+        [
+            ("", "cannot be empty"),
+            ("123start", "invalid characters"),  # can't start with number
+            ("has-dash", "invalid characters"),
+            ("has space", "invalid characters"),
+            ("has\nnewline", "invalid characters"),
+            ("has=equals", "invalid characters"),
+            ("injection\nTOKEN", "invalid characters"),
+        ],
+    )
+    def test_invalid_names(self, name: str, error_contains: str):
+        with pytest.raises(ValueError) as exc_info:
+            validate_output_name(name)
+        assert error_contains in str(exc_info.value)
+
+    def test_rejects_long_name(self):
+        """Output names over 128 characters should be rejected."""
+        long_name = "a" * 129
+        with pytest.raises(ValueError) as exc_info:
+            validate_output_name(long_name)
+        assert "maximum length" in str(exc_info.value)
+
+    def test_accepts_max_length_name(self):
+        """Output names at exactly 128 characters should be accepted."""
+        max_name = "a" * 128
+        assert validate_output_name(max_name) == max_name
+
+
+class TestValidateSha:
+    """Tests for validate_sha function."""
+
+    @pytest.mark.parametrize(
+        "sha",
+        [
+            "a" * 40,  # valid SHA-1
+            "0123456789abcdef" * 2 + "01234567",  # 40 hex chars
+            "a" * 64,  # valid SHA-256
+            "0123456789abcdef" * 4,  # 64 hex chars
+        ],
+    )
+    def test_valid_shas(self, sha: str):
+        assert validate_sha(sha) == sha
+
+    @pytest.mark.parametrize(
+        "sha,error_contains",
+        [
+            ("", "cannot be empty"),
+            ("abc", "invalid SHA format"),  # too short
+            ("a" * 39, "invalid SHA format"),  # one char too short
+            ("a" * 41, "invalid SHA format"),  # one char too long (not 64)
+            ("g" * 40, "invalid SHA format"),  # invalid hex char
+            ("A" * 40, "invalid SHA format"),  # uppercase not allowed
+            ("a" * 40 + "\n", "invalid SHA format"),  # newline injection
+        ],
+    )
+    def test_invalid_shas(self, sha: str, error_contains: str):
+        with pytest.raises(ValueError) as exc_info:
+            validate_sha(sha)
+        assert error_contains in str(exc_info.value)
+
+
+class TestGitHubOutputInjection:
+    """Tests for GITHUB_OUTPUT injection prevention."""
+
+    def test_write_output_rejects_invalid_name(self, github_output_file: Path):
+        """Verify write_output rejects names with injection attempts."""
+        with pytest.raises(ValueError):
+            write_output("sha\nTOKEN", "value")
+
+    def test_write_output_sanitizes_value_newlines(self, github_output_file: Path):
+        """Verify newlines in values are sanitized."""
+        write_output("result", "line1\nline2\rline3")
+        content = github_output_file.read_text()
+        # newlines should be replaced with spaces
+        assert "result=line1 line2 line3\n" == content
+
+    def test_write_output_with_equals_in_value(self, github_output_file: Path):
+        """Values can contain equals signs (they're not delimiters after the first)."""
+        write_output("result", "key=value=other")
+        content = github_output_file.read_text()
+        assert "result=key=value=other\n" == content
+
+    def test_main_validates_sha_before_output(self, valid_ssh_key: str, github_output_file: Path, capsys):
+        """Verify main() validates SHA format before writing to output."""
+        with patch("create_tag.create_and_push_tag") as mock_create:
+            # return an invalid SHA
+            mock_create.return_value = "not-a-valid-sha"
+            result = main(
+                args=["--tag", "v1.0.0", "--repository", "owner/repo"],
+                deploy_key=valid_ssh_key,
+            )
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "::error::" in captured.out
+        assert "Internal error" in captured.out
+
+    def test_main_accepts_valid_sha(self, valid_ssh_key: str, github_output_file: Path):
+        """Verify main() accepts valid SHA-1 hashes."""
+        with patch("create_tag.create_and_push_tag") as mock_create:
+            mock_create.return_value = "a" * 40  # valid SHA-1
+            result = main(
+                args=["--tag", "v1.0.0", "--repository", "owner/repo"],
+                deploy_key=valid_ssh_key,
+            )
+
+        assert result == 0
+        assert f"sha={'a' * 40}" in github_output_file.read_text()
+
+
+class TestTagBoundaryConditions:
+    """Tests for tag validation at boundary conditions."""
+
+    def test_tag_at_max_length(self):
+        """Tag at exactly 256 characters should be accepted."""
+        # first char must be alphanumeric, rest can include dots/dashes
+        tag = "v" + "a" * 255  # 256 total
+        assert validate_tag(tag) == tag
+
+    def test_tag_over_max_length(self):
+        """Tag over 256 characters should be rejected."""
+        tag = "v" + "a" * 256  # 257 total
+        with pytest.raises(ValidationError) as exc_info:
+            validate_tag(tag)
+        assert "invalid characters" in str(exc_info.value)
+
+    def test_tag_with_many_slashes(self):
+        """Tags can have hierarchical structure with slashes."""
+        tag = "release/2024/v1/final"
+        assert validate_tag(tag) == tag
+
+    def test_tag_with_only_valid_special_chars(self):
+        """Tags can contain dots, dashes, underscores, and slashes."""
+        tag = "v1.0.0-beta_1/release"
+        assert validate_tag(tag) == tag
+
+    def test_tag_single_char(self):
+        """Single character tags should be valid."""
+        assert validate_tag("v") == "v"
+        assert validate_tag("1") == "1"
+
+    def test_tag_rejects_double_dots_anywhere(self):
+        """Double dots should be rejected anywhere in the tag."""
+        with pytest.raises(ValidationError) as exc_info:
+            validate_tag("v1..0")
+        assert "cannot contain '..'" in str(exc_info.value)
+
+        with pytest.raises(ValidationError) as exc_info:
+            validate_tag("..v1.0")
+        assert "invalid characters" in str(exc_info.value)  # also fails regex (starts with .)
+
+
+class TestSSHCommandPathQuoting:
+    """Tests for SSH command path quoting with special characters."""
+
+    def test_ssh_command_quotes_path_with_spaces(self, tmp_path: Path):
+        """Verify paths with spaces are properly quoted in SSH command."""
+
+        # create a path with spaces
+        path_with_spaces = tmp_path / "path with spaces" / "known_hosts"
+        path_with_spaces.parent.mkdir(parents=True)
+        path_with_spaces.write_text("github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5...\n")
+
+        # create mock agent path with spaces using tmp_path
+        mock_agent_sock = str(tmp_path / "path with spaces" / "agent.12345")
+
+        valid_config = Config(
+            tag="v1.0.0",
+            deploy_key="-----BEGIN OPENSSH PRIVATE KEY-----\nbase64data\n-----END OPENSSH PRIVATE KEY-----",
+            tag_message="Release v1.0.0",
+            git_user_name="bot",
+            git_user_email="bot@example.com",
+            repository="owner/repo",
+        )
+
+        ssh_command_captured = None
+
+        def capture_set_config(key: str, value: str) -> None:
+            nonlocal ssh_command_captured
+            if key == "core.sshCommand":
+                ssh_command_captured = value
+
+        @contextmanager
+        def mock_setup_ssh_key(deploy_key: str):  # noqa: ARG001
+            yield SSHConfig(
+                auth_sock=mock_agent_sock,
+                agent_pid=12345,
+                known_hosts_path=str(path_with_spaces),
+            )
+
+        with (
+            patch("create_tag.setup_ssh_key", mock_setup_ssh_key),
+            patch("create_tag.get_git_config", return_value=None),
+            patch("create_tag.set_git_config", side_effect=capture_set_config),
+            patch("create_tag.run_git") as mock_run,
+            patch("create_tag.tag_exists_locally", return_value=False),
+            patch("create_tag.tag_exists_remotely", return_value=False),
+        ):
+            mock_run.return_value = MagicMock(stdout="abc123\n")
+            try:
+                create_and_push_tag(valid_config)
+            except (GitError, ValidationError, AttributeError):
+                pass
+
+        # verify paths are quoted
+        assert ssh_command_captured is not None
+        # shlex.quote should have quoted the paths with spaces
+        assert "'" in ssh_command_captured
+
+    def test_ssh_command_quotes_path_with_quotes(self, tmp_path: Path):
+        """Verify paths with quote characters are properly escaped."""
+        import shlex
+
+        # create a path that would need quoting using tmp_path
+        test_path = str(tmp_path / "test'path" / "agent.123")
+        quoted = shlex.quote(test_path)
+
+        # shlex.quote should escape the single quote
+        assert "'" in test_path
+        assert quoted != test_path  # it should be different (escaped)
+
+
+class TestRestoreConfigOnFailure:
+    """Tests for git config restoration on various failure scenarios."""
+
+    def test_restore_continues_after_first_failure(self, isolated_git_repo_with_origin: IsolatedGitRepo, capsys):
+        """Verify all restore attempts run even if one fails."""
+        config = Config(
+            tag="v1.0.0",
+            deploy_key="-----BEGIN OPENSSH PRIVATE KEY-----\nbase64data\n-----END OPENSSH PRIVATE KEY-----",
+            tag_message="Release v1.0.0",
+            git_user_name="bot",
+            git_user_email="bot@example.com",
+            repository="owner/repo",
+        )
+
+        call_count = {"restore": 0}
+        original_restore = _restore_git_config
+
+        def counting_restore(key: str, value: str | None) -> None:
+            call_count["restore"] += 1
+            if call_count["restore"] == 1:
+                # fail on first restore
+                raise GitError("simulated restore failure")
+            original_restore(key, value)
+
+        # create a known_hosts file for the mock
+        tmp_path = isolated_git_repo_with_origin.tmp_path
+        known_hosts = tmp_path / "known_hosts"
+        known_hosts.write_text("github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5...\n")
+        mock_agent_sock = str(tmp_path / "mock-agent" / "agent.12345")
+
+        @contextmanager
+        def mock_setup_ssh_key(deploy_key: str):  # noqa: ARG001
+            yield SSHConfig(
+                auth_sock=mock_agent_sock,
+                agent_pid=12345,
+                known_hosts_path=str(known_hosts),
+            )
+
+        with (
+            patch("create_tag.setup_ssh_key", mock_setup_ssh_key),
+            patch("create_tag._restore_git_config", side_effect=counting_restore),
+            patch("create_tag.tag_exists_locally", return_value=True),  # will cause failure
+        ):
+            with pytest.raises(ValidationError):
+                create_and_push_tag(config)
+
+        # verify multiple restore attempts were made (at least 3: sshCommand, user.name, user.email)
+        # first fails, but others should still be called
+        assert call_count["restore"] >= 3
+
+        # verify warning was printed
+        captured = capsys.readouterr()
+        assert "Warning: Failed to restore" in captured.err

--- a/.github/actions/python/README.md
+++ b/.github/actions/python/README.md
@@ -1,0 +1,64 @@
+# Python
+
+A GitHub Action that sets up a Python environment using [uv](https://github.com/astral-sh/uv) for fast, reliable dependency management.
+
+## Why use this?
+
+Setting up Python in CI typically requires multiple steps: installing Python, installing a package manager, and installing dependencies. This action combines everything into one step using uv, which is significantly faster than pip.
+
+## Usage
+
+```yaml
+- uses: ./.github/actions/python
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `python-version` | No | `3.13` | Python version to install |
+| `uv-version` | No | `0.7.x` | Version of uv to install |
+| `cache-key-prefix` | No | `181053ac82` | Prefix for cache keys (change to invalidate cache) |
+
+## Outputs
+
+None.
+
+## Prerequisites
+
+The repository should have a `pyproject.toml` file with dependencies defined. The action runs `uv sync --extra dev` to install all dependencies including dev extras.
+
+## Example Workflow
+
+```yaml
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: ./.github/actions/python
+        with:
+          python-version: "3.12"
+
+      - name: Run tests
+        run: pytest
+
+      - name: Run linter
+        run: ruff check .
+```
+
+## What It Does
+
+1. Installs uv (with caching enabled)
+2. Installs the specified Python version
+3. Runs `uv sync --extra dev` to install project dependencies
+
+## Why uv?
+
+[uv](https://github.com/astral-sh/uv) is an extremely fast Python package installer written in Rust. It's typically 10-100x faster than pip, which significantly speeds up CI runs.

--- a/.github/actions/wait-for-check/README.md
+++ b/.github/actions/wait-for-check/README.md
@@ -1,0 +1,84 @@
+# Wait for Check
+
+A GitHub Action that polls for a GitHub check run to complete and returns its conclusion. Useful for coordinating workflows that depend on other checks finishing first.
+
+## Why use this?
+
+GitHub Actions workflows sometimes need to wait for other checks to complete before proceeding. For example:
+- A release workflow that should only run after all CI checks pass
+- A deployment that depends on security scans completing
+- Coordinating between parallel jobs that can't use `needs`
+
+## Usage
+
+```yaml
+- uses: ./.github/actions/wait-for-check
+  with:
+    token: ${{ github.token }}
+    check-name: "Build"
+    ref: ${{ github.sha }}
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `token` | Yes | - | GitHub token for API calls |
+| `check-name` | Yes | - | Name of the check to wait for |
+| `ref` | Yes | - | Git ref (commit SHA) to check |
+| `timeout-seconds` | No | `600` | Maximum time to wait before timing out |
+| `interval-seconds` | No | `30` | How often to poll the GitHub API |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `conclusion` | The check conclusion: `success`, `failure`, `cancelled`, `skipped`, `timed_out`, etc. |
+
+## Example Workflow
+
+```yaml
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  wait-for-ci:
+    runs-on: ubuntu-latest
+    outputs:
+      ci-passed: ${{ steps.wait.outputs.conclusion == 'success' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Wait for CI
+        id: wait
+        uses: ./.github/actions/wait-for-check
+        with:
+          token: ${{ github.token }}
+          check-name: "CI / Build"
+          ref: ${{ github.sha }}
+          timeout-seconds: 300
+          interval-seconds: 15
+
+      - name: Check result
+        if: steps.wait.outputs.conclusion != 'success'
+        run: |
+          echo "CI check did not succeed: ${{ steps.wait.outputs.conclusion }}"
+          exit 1
+
+  release:
+    needs: wait-for-ci
+    if: needs.wait-for-ci.outputs.ci-passed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Releasing..."
+```
+
+## Behavior
+
+- Polls the GitHub API at the specified interval until the check completes or times out
+- Returns `timed_out` as the conclusion if the timeout is reached
+- Handles API errors gracefully with retries
+- The check must match by exact name

--- a/.github/workflows/validations-create-tag-via-deploy-key.yaml
+++ b/.github/workflows/validations-create-tag-via-deploy-key.yaml
@@ -1,0 +1,105 @@
+name: "Create-tag-via-deploy-key Validations"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/actions/create-tag-via-deploy-key/**"
+      - ".github/workflows/validations-create-tag-via-deploy-key.yaml"
+      - "task.d/create-tag-via-deploy-key.yaml"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/actions/create-tag-via-deploy-key/**"
+      - "task.d/create-tag-via-deploy-key.yaml"
+
+permissions:
+  contents: read
+
+jobs:
+  Static-Analysis:
+    name: "Static analysis"
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+
+      - name: Static analysis
+        run: task create-tag:static-analysis
+
+  Unit-Tests:
+    name: "Unit tests"
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+
+      - name: Run tests
+        run: task create-tag:test
+
+  Validation-Test:
+    name: "Validation test"
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # test that validation catches invalid inputs (no actual tagging)
+      - name: Test invalid tag validation
+        id: invalid-tag
+        continue-on-error: true
+        uses: ./.github/actions/create-tag-via-deploy-key
+        with:
+          tag: ""  # empty tag should fail validation
+          deploy-key: "not-a-real-key"
+
+      - name: Verify invalid tag was rejected
+        if: steps.invalid-tag.outcome != 'failure'
+        run: |
+          echo "::error::Expected validation to fail for empty tag"
+          exit 1
+
+      - name: Test invalid deploy key validation
+        id: invalid-key
+        continue-on-error: true
+        uses: ./.github/actions/create-tag-via-deploy-key
+        with:
+          tag: "v1.0.0-test"
+          deploy-key: "not-a-valid-ssh-key"
+
+      - name: Verify invalid key was rejected
+        if: steps.invalid-key.outcome != 'failure'
+        run: |
+          echo "::error::Expected validation to fail for invalid deploy key"
+          exit 1
+
+      - name: Verify all validation tests passed
+        run: echo "All validation tests passed!"

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -6,6 +6,8 @@ includes:
     taskfile: ./task.d/runson.yaml
   wait-for-check:
     taskfile: ./task.d/wait-for-check.yaml
+  create-tag:
+    taskfile: ./task.d/create-tag-via-deploy-key.yaml
 
 vars:
   OWNER: anchore

--- a/task.d/create-tag-via-deploy-key.yaml
+++ b/task.d/create-tag-via-deploy-key.yaml
@@ -1,0 +1,46 @@
+version: "3"
+
+vars:
+  ACTION_DIR: .github/actions/create-tag-via-deploy-key
+
+tasks:
+  static-analysis:
+    desc: Run all create-tag-via-deploy-key static analysis tasks
+    cmds:
+      - task: lint
+      - task: format-check
+
+  lint:
+    desc: Run ruff linter on create-tag-via-deploy-key code
+    dir: "{{ .ACTION_DIR }}"
+    cmds:
+      - pip install ruff -q
+      - ruff check .
+
+  lint-fix:
+    desc: Run ruff linter with auto-fix on create-tag-via-deploy-key code
+    dir: "{{ .ACTION_DIR }}"
+    cmds:
+      - pip install ruff -q
+      - ruff check . --fix
+
+  format:
+    desc: Format create-tag-via-deploy-key code with ruff
+    dir: "{{ .ACTION_DIR }}"
+    cmds:
+      - pip install ruff -q
+      - ruff format .
+
+  format-check:
+    desc: Check create-tag-via-deploy-key code formatting
+    dir: "{{ .ACTION_DIR }}"
+    cmds:
+      - pip install ruff -q
+      - ruff format --check .
+
+  test:
+    desc: Run create-tag-via-deploy-key tests with pytest
+    dir: "{{ .ACTION_DIR }}"
+    cmds:
+      - pip install pytest -q
+      - pytest -v


### PR DESCRIPTION
Adds a new GitHub Action that creates and pushes git tags using an SSH deploy key for authentication instead of the standard `GITHUB_TOKEN`. The default `GITHUB_TOKEN` has broad permissions that can be difficult to restrict. Using a deploy key with repository rulesets allows you to:

- Allow tag pushes while blocking direct code pushes: CI can create releases but cannot modify source code
- Maintain fine-grained control: deploy keys are scoped to specific repositories and can be revoked independently
- Comply with branch/tag protection rules: works within existing security policies

It does this by:

1. Using ssh-agent and loading the deploy key via stdin (key is never written to disk)
2. Configuring git to use SSH with strict host key verification (using baked-in GitHub host keys)
3. Creating an annotated git tag on the current commit
4. Pushing the tag to the remote repository

I also took the time to add READMEs for all of the actions we currently have