### PR TITLE
Fix tag available check to refuse prefix matching

### DIFF
--- a/.github/workflows/check-version-available.yaml
+++ b/.github/workflows/check-version-available.yaml
@@ -64,11 +64,14 @@ jobs:
       - name: Check if tag already exists
         env:
           VERSION: ${{ inputs.version }}
+          REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          # use GitHub API to check if tag exists (more reliable than git ls-remote)
-          HTTP_STATUS=$(gh api "repos/${{ github.repository }}/git/refs/tags/${VERSION}" \
-            -i 2>&1 | head -1 | awk '{print $2}' || echo "000")
+          # use the singular `git/ref/tags/<name>` endpoint for an exact-match
+          # lookup. The plural `git/refs/tags/<name>` endpoint does prefix
+          # matching and would return 200 for e.g. v0.1.0 if v0.1.0-rc1 exists.
+          HTTP_STATUS=$(gh api "repos/${REPO}/git/ref/tags/${VERSION}" --silent -i 2>/dev/null | head -1 | awk '{print $2}')
+          HTTP_STATUS="${HTTP_STATUS:-000}"
 
           if [[ "${HTTP_STATUS}" == "200" ]]; then
             echo "::error::tag '${VERSION}' already exists"


### PR DESCRIPTION
Switched the tag-existence check from `git/refs/tags/{name}` (prefix match,
returns an array) to `git/ref/tags/{name}` (exact match, returns 404 when
absent). The previous form treated any `200` as "tag exists", producing a
false positive whenever a related pre-release tag was already pushed.

For example, with tags `v0.1.0-rc1`, `v0.1.0-rc2`, `v0.1.0-rc3` present and `v0.1.0` not:

```
$ gh api "repos/OWNER/REPO/git/refs/tags/v0.1.0" -i | head -1
HTTP/2.0 200 OK    # matches the rc tags by prefix — wrong

$ gh api "repos/OWNER/REPO/git/ref/tags/v0.1.0" -i | head -1
HTTP/2.0 404 Not Found    # correct
```

Additional fixes:
- `${{ github.repository }}` moved into `env:` as `REPO`.
- `${HTTP_STATUS:-000}` replaces a `|| echo "000"` that was bound to `awk`
  and never fired on `gh api` failure.
