### PR TITLE
Ensure we enumerate github API pages before concluding

### DIFF
--- a/.github/actions/wait-for-check/README.md
+++ b/.github/actions/wait-for-check/README.md
@@ -28,7 +28,7 @@ GitHub Actions workflows sometimes need to wait for other checks to complete bef
 | `ref` | Yes | - | Git ref (commit SHA) to check |
 | `timeout-seconds` | No | `600` | Maximum time to wait for a check to complete before timing out |
 | `interval-seconds` | No | `30` | How often to poll the GitHub API |
-| `not-found-timeout-seconds` | No | `60` | Time to wait for a check with the given name to appear at all (any status) before giving up early. Distinct from `timeout-seconds`, which bounds how long to wait for an already-seen check to complete |
+| `not-found-timeout-seconds` | No | `90` | Time to wait for a check with the given name to appear at all (any status) before giving up early. Distinct from `timeout-seconds`, which bounds how long to wait for an already-seen check to complete |
 | `verbose` | No | `false` | Log the check-run names seen on each poll |
 
 ## Outputs
@@ -84,5 +84,7 @@ jobs:
 - Returns `timed_out` as the conclusion if the timeout is reached
 - Returns `not_found` if the named check never appears within `not-found-timeout-seconds` (typically a name mismatch or a check that never started)
 - Handles API errors gracefully with retries
+- Fails fast with conclusion `auth_error` on an HTTP 401 (invalid/missing token) rather than polling to the timeout
+- Honors GitHub rate limits: on a 403/429 carrying `Retry-After` or `x-ratelimit-reset`, it waits until the window resets (capped to the remaining timeout) instead of polling on the fixed interval
 - Matches the check name in full (case-insensitive, whitespace-trimmed) — not by substring
 - When several check runs share the same name, **all** of them must succeed (fails closed)

--- a/.github/actions/wait-for-check/README.md
+++ b/.github/actions/wait-for-check/README.md
@@ -24,10 +24,12 @@ GitHub Actions workflows sometimes need to wait for other checks to complete bef
 | Input | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `token` | Yes | - | GitHub token for API calls |
-| `check-name` | Yes | - | Name of the check to wait for |
+| `check-name` | Yes | - | Name of the check to wait for. Matched case-insensitively with surrounding whitespace trimmed, but otherwise in full (no substring matching) |
 | `ref` | Yes | - | Git ref (commit SHA) to check |
-| `timeout-seconds` | No | `600` | Maximum time to wait before timing out |
+| `timeout-seconds` | No | `600` | Maximum time to wait for a check to complete before timing out |
 | `interval-seconds` | No | `30` | How often to poll the GitHub API |
+| `not-found-timeout-seconds` | No | `60` | Time to wait for a check with the given name to appear at all (any status) before giving up early. Distinct from `timeout-seconds`, which bounds how long to wait for an already-seen check to complete |
+| `verbose` | No | `false` | Log the check-run names seen on each poll |
 
 ## Outputs
 
@@ -80,5 +82,7 @@ jobs:
 
 - Polls the GitHub API at the specified interval until the check completes or times out
 - Returns `timed_out` as the conclusion if the timeout is reached
+- Returns `not_found` if the named check never appears within `not-found-timeout-seconds` (typically a name mismatch or a check that never started)
 - Handles API errors gracefully with retries
-- The check must match by exact name
+- Matches the check name in full (case-insensitive, whitespace-trimmed) — not by substring
+- When several check runs share the same name, **all** of them must succeed (fails closed)

--- a/.github/actions/wait-for-check/action.yaml
+++ b/.github/actions/wait-for-check/action.yaml
@@ -6,7 +6,7 @@ inputs:
     description: 'GitHub token for API calls'
     required: true
   check-name:
-    description: 'Name of the check to wait for'
+    description: 'Name of the check to wait for (matched case-insensitively and whitespace-trimmed, but in full - no substring matching)'
     required: true
   ref:
     description: 'Git ref (commit SHA) to check'
@@ -19,6 +19,14 @@ inputs:
     description: 'Polling interval in seconds (default: 30)'
     required: false
     default: '30'
+  not-found-timeout-seconds:
+    description: 'Time to wait for the check to appear at all before giving up (default: 60)'
+    required: false
+    default: '60'
+  verbose:
+    description: 'Log the check-run names seen on each poll (default: false)'
+    required: false
+    default: 'false'
 
 outputs:
   conclusion:
@@ -37,12 +45,20 @@ runs:
         INPUT_REF: ${{ inputs.ref }}
         INPUT_TIMEOUT: ${{ inputs.timeout-seconds }}
         INPUT_INTERVAL: ${{ inputs.interval-seconds }}
+        INPUT_NOT_FOUND_TIMEOUT: ${{ inputs.not-found-timeout-seconds }}
+        INPUT_VERBOSE: ${{ inputs.verbose }}
         INPUT_REPOSITORY: ${{ github.repository }}
       run: |
+        verbose_flag=""
+        if [ "$INPUT_VERBOSE" = "true" ]; then
+          verbose_flag="--verbose"
+        fi
         python3 "${{ github.action_path }}/wait_for_check.py" \
           --token "$INPUT_TOKEN" \
           --repository "$INPUT_REPOSITORY" \
           --check-name "$INPUT_CHECK_NAME" \
           --ref "$INPUT_REF" \
           --timeout-seconds "$INPUT_TIMEOUT" \
-          --interval-seconds "$INPUT_INTERVAL"
+          --interval-seconds "$INPUT_INTERVAL" \
+          --not-found-timeout-seconds "$INPUT_NOT_FOUND_TIMEOUT" \
+          $verbose_flag

--- a/.github/actions/wait-for-check/action.yaml
+++ b/.github/actions/wait-for-check/action.yaml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: '30'
   not-found-timeout-seconds:
-    description: 'Time to wait for the check to appear at all before giving up (default: 60)'
+    description: 'Time to wait for the check to appear at all before giving up (default: 90)'
     required: false
-    default: '60'
+    default: '90'
   verbose:
     description: 'Log the check-run names seen on each poll (default: false)'
     required: false

--- a/.github/actions/wait-for-check/test_wait_for_check.py
+++ b/.github/actions/wait-for-check/test_wait_for_check.py
@@ -1,7 +1,7 @@
 """Unit tests for wait_for_check.py"""
 
 import json
-from urllib.error import URLError
+from urllib.error import HTTPError, URLError
 
 import pytest
 
@@ -568,3 +568,45 @@ class TestWaitForCheckDiagnostics:
         )
 
         assert wait_for_check(_diag_config()) == "success"
+
+
+class TestWaitForCheckAuthErrors:
+    """Tests for fast-failing on auth/permission errors."""
+
+    def test_401_fails_fast(self, monkeypatch, capsys):
+        """A 401 must abort immediately rather than poll to the timeout."""
+        _freeze_clock(monkeypatch)
+        calls: list[int] = []
+
+        def boom(*args, **kwargs):
+            calls.append(1)
+            raise HTTPError("https://api.github.com", 401, "Unauthorized", {}, None)
+
+        monkeypatch.setattr("wait_for_check.fetch_check_runs", boom)
+
+        result = wait_for_check(_diag_config())
+
+        err = capsys.readouterr().err
+        assert result == "auth_error"
+        # only polled once - did not keep retrying
+        assert len(calls) == 1
+        assert "HTTP 401" in err
+
+    @pytest.mark.parametrize("code", [403, 500, 502])
+    def test_non_401_http_error_keeps_polling(self, monkeypatch, code):
+        """Other HTTP errors (incl. 403, which covers rate limits) should be retried."""
+        _freeze_clock(monkeypatch)
+        calls: list[int] = []
+
+        def flaky(*args, **kwargs):
+            calls.append(1)
+            if len(calls) < 3:
+                raise HTTPError("https://api.github.com", code, "Transient", {}, None)
+            return [{"name": "Build", "status": "completed", "conclusion": "success"}]
+
+        monkeypatch.setattr("wait_for_check.fetch_check_runs", flaky)
+
+        result = wait_for_check(_diag_config())
+
+        assert result == "success"
+        assert len(calls) == 3

--- a/.github/actions/wait-for-check/test_wait_for_check.py
+++ b/.github/actions/wait-for-check/test_wait_for_check.py
@@ -1,6 +1,7 @@
 """Unit tests for wait_for_check.py"""
 
 import json
+from email.message import Message
 from urllib.error import HTTPError, URLError
 
 import pytest
@@ -138,7 +139,7 @@ class TestValidateConfig:
             timeout_seconds=600,
             interval_seconds=30,
         )
-        assert config.not_found_timeout_seconds == 60
+        assert config.not_found_timeout_seconds == 90
         assert config.verbose is False
 
     def test_interval_greater_than_timeout(self):
@@ -384,7 +385,7 @@ class TestParseArgs:
         )
         assert args.timeout_seconds == 600
         assert args.interval_seconds == 30
-        assert args.not_found_timeout_seconds == 60
+        assert args.not_found_timeout_seconds == 90
         assert args.verbose is False
 
     def test_missing_required_arg(self):
@@ -569,6 +570,22 @@ class TestWaitForCheckDiagnostics:
 
         assert wait_for_check(_diag_config()) == "success"
 
+    def test_seen_but_never_completes_times_out(self, monkeypatch, capsys):
+        """A check that is found but stays in_progress past the timeout is timed_out, not not_found."""
+        _freeze_clock(monkeypatch)
+        monkeypatch.setattr(
+            "wait_for_check.fetch_check_runs",
+            lambda *a, **k: [{"name": "Build", "status": "in_progress", "conclusion": None}],
+        )
+
+        result = wait_for_check(_diag_config())
+
+        out = capsys.readouterr().out
+        assert result == "timed_out"
+        # the never-seen diagnostics must not fire when the check was actually seen
+        assert "found but never reached a completed state" in out
+        assert "does not match" not in out
+
 
 class TestWaitForCheckAuthErrors:
     """Tests for fast-failing on auth/permission errors."""
@@ -610,3 +627,102 @@ class TestWaitForCheckAuthErrors:
 
         assert result == "success"
         assert len(calls) == 3
+
+
+def _recording_clock(monkeypatch):
+    """Like _freeze_clock, but also records each slept duration in order."""
+    clock = {"now": 1000.0}
+    sleeps: list[float] = []
+    monkeypatch.setattr("wait_for_check.time.time", lambda: clock["now"])
+
+    def sleep(s):
+        sleeps.append(s)
+        clock["now"] += s
+
+    monkeypatch.setattr("wait_for_check.time.sleep", sleep)
+    return clock, sleeps
+
+
+def _rate_limited_error(code, headers):
+    """Build an HTTPError carrying case-insensitive headers, like a real response."""
+    message = Message()
+    for key, value in headers.items():
+        message[key] = value
+    return HTTPError("https://api.github.com", code, "Rate limited", message, None)
+
+
+class TestWaitForCheckRateLimits:
+    """Tests for honoring GitHub rate-limit headers when backing off."""
+
+    def test_honors_retry_after(self, monkeypatch):
+        """A Retry-After header should drive the backoff instead of the interval."""
+        _, sleeps = _recording_clock(monkeypatch)
+        calls: list[int] = []
+
+        def flaky(*args, **kwargs):
+            calls.append(1)
+            if len(calls) == 1:
+                raise _rate_limited_error(403, {"Retry-After": "45"})
+            return [{"name": "Build", "status": "completed", "conclusion": "success"}]
+
+        monkeypatch.setattr("wait_for_check.fetch_check_runs", flaky)
+
+        result = wait_for_check(_diag_config(timeout_seconds=600, not_found_timeout_seconds=120))
+
+        assert result == "success"
+        assert sleeps == [45]
+
+    def test_honors_ratelimit_reset(self, monkeypatch):
+        """x-ratelimit-remaining: 0 + reset epoch should drive the backoff."""
+        _, sleeps = _recording_clock(monkeypatch)
+        calls: list[int] = []
+
+        def flaky(*args, **kwargs):
+            calls.append(1)
+            if len(calls) == 1:
+                # clock starts at 1000.0, so a reset at 1030 means a 30s wait
+                raise _rate_limited_error(
+                    403,
+                    {"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "1030"},
+                )
+            return [{"name": "Build", "status": "completed", "conclusion": "success"}]
+
+        monkeypatch.setattr("wait_for_check.fetch_check_runs", flaky)
+
+        result = wait_for_check(_diag_config(timeout_seconds=600, not_found_timeout_seconds=120))
+
+        assert result == "success"
+        assert sleeps == [30]
+
+    def test_plain_403_uses_interval(self, monkeypatch):
+        """A 403 with no rate-limit headers falls back to the normal interval."""
+        _, sleeps = _recording_clock(monkeypatch)
+        calls: list[int] = []
+
+        def flaky(*args, **kwargs):
+            calls.append(1)
+            if len(calls) == 1:
+                raise _rate_limited_error(403, {})
+            return [{"name": "Build", "status": "completed", "conclusion": "success"}]
+
+        monkeypatch.setattr("wait_for_check.fetch_check_runs", flaky)
+
+        result = wait_for_check(_diag_config(interval_seconds=7, timeout_seconds=600))
+
+        assert result == "success"
+        assert sleeps == [7]
+
+    def test_reset_capped_to_deadline(self, monkeypatch):
+        """A reset beyond the deadline should not sleep past the timeout."""
+        _, sleeps = _recording_clock(monkeypatch)
+
+        def always_rate_limited(*args, **kwargs):
+            raise _rate_limited_error(403, {"Retry-After": "100000"})
+
+        monkeypatch.setattr("wait_for_check.fetch_check_runs", always_rate_limited)
+
+        result = wait_for_check(_diag_config(timeout_seconds=10, not_found_timeout_seconds=9))
+
+        assert result == "timed_out"
+        # never slept longer than the remaining budget
+        assert all(s <= 10 for s in sleeps)

--- a/.github/actions/wait-for-check/test_wait_for_check.py
+++ b/.github/actions/wait-for-check/test_wait_for_check.py
@@ -1,12 +1,21 @@
 """Unit tests for wait_for_check.py"""
 
+import json
+from urllib.error import URLError
+
 import pytest
 
 from wait_for_check import (
+    MAX_PAGES,
+    PER_PAGE,
+    Config,
     ValidationError,
-    find_completed_check,
+    fetch_check_runs,
+    find_matching_checks,
     parse_args,
+    resolve_conclusion,
     validate_config,
+    wait_for_check,
     write_output,
 )
 
@@ -95,6 +104,42 @@ class TestValidateConfig:
                 timeout_seconds=600,
                 interval_seconds=-1,
             )
+
+    def test_invalid_not_found_timeout(self):
+        with pytest.raises(ValidationError, match="not_found_timeout_seconds must be positive"):
+            validate_config(
+                token="token",
+                repository="owner/repo",
+                check_name="test",
+                ref="abc123",
+                timeout_seconds=600,
+                interval_seconds=30,
+                not_found_timeout_seconds=0,
+            )
+
+    def test_not_found_timeout_not_less_than_timeout(self):
+        with pytest.raises(ValidationError, match="not_found_timeout_seconds.*must be less than"):
+            validate_config(
+                token="token",
+                repository="owner/repo",
+                check_name="test",
+                ref="abc123",
+                timeout_seconds=60,
+                interval_seconds=30,
+                not_found_timeout_seconds=60,
+            )
+
+    def test_not_found_timeout_and_verbose_defaults(self):
+        config = validate_config(
+            token="token",
+            repository="owner/repo",
+            check_name="test",
+            ref="abc123",
+            timeout_seconds=600,
+            interval_seconds=30,
+        )
+        assert config.not_found_timeout_seconds == 60
+        assert config.verbose is False
 
     def test_interval_greater_than_timeout(self):
         with pytest.raises(ValidationError, match="interval_seconds.*must be less than"):
@@ -194,50 +239,102 @@ class TestValidateConfig:
             )
 
 
-class TestFindCompletedCheck:
-    """Tests for find_completed_check function."""
+class TestFindMatchingChecks:
+    """Tests for find_matching_checks function."""
 
-    def test_finds_completed_check(self):
+    def test_finds_matching_check(self):
         check_runs = [
             {"name": "Unit tests", "status": "completed", "conclusion": "success"},
             {"name": "Lint", "status": "in_progress", "conclusion": None},
         ]
-        result = find_completed_check(check_runs, "Unit tests")
-        assert result == "success"
+        result = find_matching_checks(check_runs, "Unit tests")
+        assert result == [check_runs[0]]
 
-    def test_returns_none_for_in_progress(self):
-        check_runs = [
-            {"name": "Unit tests", "status": "in_progress", "conclusion": None},
-        ]
-        result = find_completed_check(check_runs, "Unit tests")
-        assert result is None
-
-    def test_returns_none_for_missing_check(self):
+    def test_returns_empty_for_missing_check(self):
         check_runs = [
             {"name": "Other check", "status": "completed", "conclusion": "success"},
         ]
-        result = find_completed_check(check_runs, "Unit tests")
-        assert result is None
+        assert find_matching_checks(check_runs, "Unit tests") == []
 
     def test_handles_empty_list(self):
-        result = find_completed_check([], "Unit tests")
-        assert result is None
+        assert find_matching_checks([], "Unit tests") == []
 
-    def test_handles_failure_conclusion(self):
+    def test_case_insensitive_match(self):
+        """Names that differ only by case should still match."""
         check_runs = [
-            {"name": "Unit tests", "status": "completed", "conclusion": "failure"},
+            {"name": "Static Analysis", "status": "completed", "conclusion": "success"},
         ]
-        result = find_completed_check(check_runs, "Unit tests")
-        assert result == "failure"
+        assert find_matching_checks(check_runs, "static analysis") == check_runs
+        assert find_matching_checks(check_runs, "STATIC ANALYSIS") == check_runs
 
-    def test_exact_name_match(self):
-        """Ensure we don't do partial matching."""
+    def test_whitespace_trimmed_match(self):
+        """Leading/trailing whitespace should not prevent a match."""
+        check_runs = [
+            {"name": "  Unit tests  ", "status": "completed", "conclusion": "success"},
+        ]
+        assert find_matching_checks(check_runs, "Unit tests") == check_runs
+
+    def test_no_partial_match(self):
+        """Ensure we don't do partial/substring matching."""
         check_runs = [
             {"name": "Unit tests (fast)", "status": "completed", "conclusion": "success"},
-            {"name": "Unit tests", "status": "in_progress", "conclusion": None},
         ]
-        result = find_completed_check(check_runs, "Unit tests")
-        assert result is None
+        assert find_matching_checks(check_runs, "Unit tests") == []
+
+    def test_returns_all_duplicates(self):
+        """All check runs sharing a name should be returned."""
+        check_runs = [
+            {"name": "Build", "status": "completed", "conclusion": "success"},
+            {"name": "build", "status": "completed", "conclusion": "failure"},
+        ]
+        assert find_matching_checks(check_runs, "Build") == check_runs
+
+
+class TestResolveConclusion:
+    """Tests for resolve_conclusion function."""
+
+    def test_empty_returns_none(self):
+        """No matching runs must never resolve to success."""
+        assert resolve_conclusion([]) is None
+
+    def test_single_success(self):
+        matches = [{"name": "x", "status": "completed", "conclusion": "success"}]
+        assert resolve_conclusion(matches) == "success"
+
+    def test_single_failure(self):
+        matches = [{"name": "x", "status": "completed", "conclusion": "failure"}]
+        assert resolve_conclusion(matches) == "failure"
+
+    def test_pending_returns_none(self):
+        matches = [{"name": "x", "status": "in_progress", "conclusion": None}]
+        assert resolve_conclusion(matches) is None
+
+    def test_pending_when_any_incomplete(self):
+        """Wait for the full set: one pending run keeps the verdict open."""
+        matches = [
+            {"name": "x", "status": "completed", "conclusion": "success"},
+            {"name": "x", "status": "in_progress", "conclusion": None},
+        ]
+        assert resolve_conclusion(matches) is None
+
+    def test_duplicates_all_success(self):
+        matches = [
+            {"name": "x", "status": "completed", "conclusion": "success"},
+            {"name": "x", "status": "completed", "conclusion": "success"},
+        ]
+        assert resolve_conclusion(matches) == "success"
+
+    def test_duplicates_fail_closed(self):
+        """If any matching run failed, the result is non-success."""
+        matches = [
+            {"name": "x", "status": "completed", "conclusion": "success"},
+            {"name": "x", "status": "completed", "conclusion": "failure"},
+        ]
+        assert resolve_conclusion(matches) == "failure"
+
+    def test_completed_without_conclusion_treated_as_failure(self):
+        matches = [{"name": "x", "status": "completed", "conclusion": None}]
+        assert resolve_conclusion(matches) == "failure"
 
 
 class TestParseArgs:
@@ -258,6 +355,9 @@ class TestParseArgs:
                 "300",
                 "--interval-seconds",
                 "15",
+                "--not-found-timeout-seconds",
+                "90",
+                "--verbose",
             ]
         )
         assert args.token == "ghp_xxx"
@@ -266,6 +366,8 @@ class TestParseArgs:
         assert args.ref == "abc123"
         assert args.timeout_seconds == 300
         assert args.interval_seconds == 15
+        assert args.not_found_timeout_seconds == 90
+        assert args.verbose is True
 
     def test_defaults(self):
         args = parse_args(
@@ -282,6 +384,8 @@ class TestParseArgs:
         )
         assert args.timeout_seconds == 600
         assert args.interval_seconds == 30
+        assert args.not_found_timeout_seconds == 60
+        assert args.verbose is False
 
     def test_missing_required_arg(self):
         with pytest.raises(SystemExit):
@@ -333,3 +437,134 @@ class TestWriteOutput:
 
         content = output_file.read_text()
         assert content == "conclusion=success\n"
+
+
+class _FakeResponse:
+    """Minimal stand-in for the urlopen context manager."""
+
+    def __init__(self, payload):
+        self._body = json.dumps(payload).encode("utf-8")
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+def _make_fake_urlopen(pages, calls):
+    """Build a urlopen replacement that serves `pages` in order and records URLs."""
+
+    def fake_urlopen(request, timeout=None):  # noqa: ARG001
+        calls.append(request.full_url)
+        return _FakeResponse(pages[len(calls) - 1])
+
+    return fake_urlopen
+
+
+class TestFetchCheckRuns:
+    """Tests for fetch_check_runs pagination."""
+
+    def test_single_page(self, monkeypatch):
+        pages = [{"total_count": 2, "check_runs": [{"name": "a"}, {"name": "b"}]}]
+        calls: list[str] = []
+        monkeypatch.setattr("wait_for_check.urlopen", _make_fake_urlopen(pages, calls))
+
+        runs = fetch_check_runs("token", "owner/repo", "abc123")
+
+        assert [r["name"] for r in runs] == ["a", "b"]
+        assert len(calls) == 1
+
+    def test_follows_pagination(self, monkeypatch):
+        page1 = {"total_count": 150, "check_runs": [{"name": f"c{i}"} for i in range(PER_PAGE)]}
+        page2 = {"total_count": 150, "check_runs": [{"name": f"c{i}"} for i in range(PER_PAGE, 150)]}
+        calls: list[str] = []
+        monkeypatch.setattr("wait_for_check.urlopen", _make_fake_urlopen([page1, page2], calls))
+
+        runs = fetch_check_runs("token", "owner/repo", "abc123")
+
+        assert len(runs) == 150
+        assert len(calls) == 2
+        assert "page=2" in calls[1]
+
+    def test_respects_max_pages_and_warns(self, monkeypatch, capsys):
+        # every page is full and total_count never satisfied, so only the cap stops us
+        full_page = {"total_count": 10_000, "check_runs": [{"name": "x"} for _ in range(PER_PAGE)]}
+        calls: list[str] = []
+        monkeypatch.setattr("wait_for_check.urlopen", _make_fake_urlopen([full_page] * MAX_PAGES, calls))
+
+        runs = fetch_check_runs("token", "owner/repo", "abc123")
+
+        assert len(calls) == MAX_PAGES
+        assert len(runs) == MAX_PAGES * PER_PAGE
+        assert "pagination cap" in capsys.readouterr().out
+
+
+def _diag_config(**overrides):
+    base = {
+        "token": "token",
+        "repository": "owner/repo",
+        "check_name": "Build",
+        "ref": "abc123",
+        "timeout_seconds": 10,
+        "interval_seconds": 1,
+        "not_found_timeout_seconds": 3,
+        "verbose": False,
+    }
+    base.update(overrides)
+    return Config(**base)
+
+
+def _freeze_clock(monkeypatch):
+    """Make time.time advance only when time.sleep is called, so the loop runs fast."""
+    clock = {"now": 1000.0}
+    monkeypatch.setattr("wait_for_check.time.time", lambda: clock["now"])
+    monkeypatch.setattr("wait_for_check.time.sleep", lambda s: clock.__setitem__("now", clock["now"] + s))
+    return clock
+
+
+class TestWaitForCheckDiagnostics:
+    """Tests for the not-found / never-seen reporting in wait_for_check."""
+
+    def test_persistent_api_errors_reported_as_connectivity(self, monkeypatch, capsys):
+        """When every poll fails, blame the API - not a name mismatch."""
+        _freeze_clock(monkeypatch)
+
+        def boom(*args, **kwargs):
+            raise URLError("connection refused")
+
+        monkeypatch.setattr("wait_for_check.fetch_check_runs", boom)
+
+        result = wait_for_check(_diag_config())
+
+        out = capsys.readouterr().out
+        assert result == "not_found"
+        assert "every GitHub API request failed" in out
+        assert "does not match" not in out
+
+    def test_unmatched_name_reports_available_checks(self, monkeypatch, capsys):
+        """When polling succeeds but the name is absent, blame the name and list what was seen."""
+        _freeze_clock(monkeypatch)
+        monkeypatch.setattr(
+            "wait_for_check.fetch_check_runs",
+            lambda *a, **k: [{"name": "Other", "status": "completed", "conclusion": "success"}],
+        )
+
+        result = wait_for_check(_diag_config())
+
+        out = capsys.readouterr().out
+        assert result == "not_found"
+        assert "does not match" in out
+        assert "Other" in out
+
+    def test_success_returns_conclusion(self, monkeypatch, capsys):
+        _freeze_clock(monkeypatch)
+        monkeypatch.setattr(
+            "wait_for_check.fetch_check_runs",
+            lambda *a, **k: [{"name": "build", "status": "completed", "conclusion": "success"}],
+        )
+
+        assert wait_for_check(_diag_config()) == "success"

--- a/.github/actions/wait-for-check/wait_for_check.py
+++ b/.github/actions/wait-for-check/wait_for_check.py
@@ -37,7 +37,7 @@ class Config(NamedTuple):
     # how long to wait for a check with the given name to appear at all (any
     # status) before giving up early. distinct from timeout_seconds, which
     # bounds how long we wait for an already-seen check to complete.
-    not_found_timeout_seconds: int = 60
+    not_found_timeout_seconds: int = 90
     verbose: bool = False
 
 
@@ -52,7 +52,7 @@ def validate_config(
     ref: str | None,
     timeout_seconds: int,
     interval_seconds: int,
-    not_found_timeout_seconds: int = 60,
+    not_found_timeout_seconds: int = 90,
     verbose: bool = False,
 ) -> Config:
     """Validate all inputs and return a Config object.
@@ -218,6 +218,42 @@ def _seen_names(check_runs: list[dict]) -> list[str]:
     return sorted({(c.get("name") or "") for c in check_runs})
 
 
+def _rate_limit_delay(error: HTTPError) -> float | None:
+    """Return how many seconds to wait before retrying a rate-limited response.
+
+    GitHub signals rate limiting on a 403/429 in one of two ways:
+    - a Retry-After header (delta-seconds), used for secondary rate limits, or
+    - x-ratelimit-remaining: 0 plus an x-ratelimit-reset epoch, for primary limits.
+
+    Returns None if the response does not look rate-limited, so the caller falls
+    back to the normal polling interval. Header lookups are case-insensitive.
+    """
+    if error.code not in (403, 429):
+        return None
+
+    headers = error.headers
+    if headers is None:
+        return None
+
+    retry_after = headers.get("Retry-After")
+    if retry_after is not None:
+        try:
+            # github sends delta-seconds here; ignore the rarer HTTP-date form
+            return max(0.0, float(retry_after))
+        except ValueError:
+            return None
+
+    if headers.get("X-RateLimit-Remaining") == "0":
+        reset = headers.get("X-RateLimit-Reset")
+        if reset is not None:
+            try:
+                return max(0.0, float(reset) - time.time())
+            except ValueError:
+                return None
+
+    return None
+
+
 def wait_for_check(config: Config) -> str:
     """Poll for a check to complete.
 
@@ -239,6 +275,8 @@ def wait_for_check(config: Config) -> str:
     )
 
     while time.time() < deadline:
+        # how long to wait before the next poll; a rate-limit response overrides this
+        rate_limit_delay: float | None = None
         try:
             check_runs = fetch_check_runs(config.token, config.repository, config.ref)
             ever_fetched = True
@@ -271,7 +309,16 @@ def wait_for_check(config: Config) -> str:
                     file=sys.stderr,
                 )
                 return "auth_error"
-            print(f"::warning::API request failed: {e}", file=sys.stderr)
+            # back off until the window resets if GitHub told us we're rate limited
+            rate_limit_delay = _rate_limit_delay(e)
+            if rate_limit_delay is not None:
+                print(
+                    f"::warning::GitHub API rate limit hit (HTTP {e.code}); waiting "
+                    f"{int(rate_limit_delay)}s for the limit to reset.",
+                    file=sys.stderr,
+                )
+            else:
+                print(f"::warning::API request failed: {e}", file=sys.stderr)
         except URLError as e:
             last_error = e
             print(f"::warning::API request failed: {e}", file=sys.stderr)
@@ -288,10 +335,20 @@ def wait_for_check(config: Config) -> str:
             )
             return "not_found"
 
-        remaining = int(deadline - time.time())
+        remaining = deadline - time.time()
+        if remaining <= 0:
+            break
+
+        # honor a rate-limit reset when present, but never poll faster than the
+        # configured interval and never sleep past the overall deadline
+        sleep_seconds = config.interval_seconds
+        if rate_limit_delay is not None:
+            sleep_seconds = max(config.interval_seconds, rate_limit_delay)
+        sleep_seconds = min(sleep_seconds, remaining)
+
         state = "seen, waiting to complete" if ever_seen else "not found yet"
-        print(f"Check '{config.check_name}' {state}. {remaining}s remaining...")
-        time.sleep(config.interval_seconds)
+        print(f"Check '{config.check_name}' {state}. {int(remaining)}s remaining...")
+        time.sleep(sleep_seconds)
 
     # full timeout reached
     if ever_seen:
@@ -386,8 +443,8 @@ def parse_args(args: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--not-found-timeout-seconds",
         type=int,
-        default=60,
-        help="Time to wait for the check to appear at all before giving up (default: 60)",
+        default=90,
+        help="Time to wait for the check to appear at all before giving up (default: 90)",
     )
     parser.add_argument(
         "-v",

--- a/.github/actions/wait-for-check/wait_for_check.py
+++ b/.github/actions/wait-for-check/wait_for_check.py
@@ -222,7 +222,8 @@ def wait_for_check(config: Config) -> str:
     """Poll for a check to complete.
 
     Returns:
-        The check conclusion (e.g., "success", "failure", "timed_out", "not_found").
+        The check conclusion (e.g., "success", "failure", "timed_out", "not_found",
+        "auth_error").
     """
     start = time.time()
     deadline = start + config.timeout_seconds
@@ -255,7 +256,23 @@ def wait_for_check(config: Config) -> str:
                     print(f"Check '{config.check_name}' completed with conclusion: {conclusion}")
                     return conclusion
 
-        except (HTTPError, URLError) as e:
+        except HTTPError as e:
+            last_error = e
+            # 401 means the token is invalid or missing - that will never resolve
+            # by polling, so bail immediately rather than burning the whole timeout.
+            # note: 403 is deliberately NOT treated as fatal here, since GitHub also
+            # returns 403 for (transient) secondary rate limits, which retrying clears.
+            if e.code == 401:
+                print(
+                    f"::error::GitHub API returned HTTP 401 ({e.reason}) for ref {config.ref}. "
+                    f"This is an authentication failure (invalid or missing token) that will not "
+                    f"resolve by retrying; verify the token is valid and has 'checks: read' and "
+                    f"'contents: read' permissions.",
+                    file=sys.stderr,
+                )
+                return "auth_error"
+            print(f"::warning::API request failed: {e}", file=sys.stderr)
+        except URLError as e:
             last_error = e
             print(f"::warning::API request failed: {e}", file=sys.stderr)
 

--- a/.github/actions/wait-for-check/wait_for_check.py
+++ b/.github/actions/wait-for-check/wait_for_check.py
@@ -18,6 +18,12 @@ from typing import NamedTuple
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
+# github caps check-runs responses at 100 per page
+PER_PAGE = 100
+
+# safety bound on pagination so a misbehaving API can't loop forever
+MAX_PAGES = 10
+
 
 class Config(NamedTuple):
     """Validated configuration for the wait operation."""
@@ -28,6 +34,11 @@ class Config(NamedTuple):
     ref: str
     timeout_seconds: int
     interval_seconds: int
+    # how long to wait for a check with the given name to appear at all (any
+    # status) before giving up early. distinct from timeout_seconds, which
+    # bounds how long we wait for an already-seen check to complete.
+    not_found_timeout_seconds: int = 60
+    verbose: bool = False
 
 
 class ValidationError(Exception):
@@ -41,6 +52,8 @@ def validate_config(
     ref: str | None,
     timeout_seconds: int,
     interval_seconds: int,
+    not_found_timeout_seconds: int = 60,
+    verbose: bool = False,
 ) -> Config:
     """Validate all inputs and return a Config object.
 
@@ -75,6 +88,15 @@ def validate_config(
     if interval_seconds >= timeout_seconds:
         errors.append(f"interval_seconds ({interval_seconds}) must be less than timeout_seconds ({timeout_seconds})")
 
+    if not_found_timeout_seconds <= 0:
+        errors.append(f"not_found_timeout_seconds must be positive, got: {not_found_timeout_seconds}")
+    elif not_found_timeout_seconds >= timeout_seconds:
+        # otherwise the early give-up never fires - the full timeout is reached first
+        errors.append(
+            f"not_found_timeout_seconds ({not_found_timeout_seconds}) must be less than "
+            f"timeout_seconds ({timeout_seconds})"
+        )
+
     if errors:
         raise ValidationError("; ".join(errors))
 
@@ -85,72 +107,230 @@ def validate_config(
         ref=ref,  # type: ignore[arg-type]
         timeout_seconds=timeout_seconds,
         interval_seconds=interval_seconds,
+        not_found_timeout_seconds=not_found_timeout_seconds,
+        verbose=verbose,
     )
 
 
 def fetch_check_runs(token: str, repository: str, ref: str) -> list[dict]:
-    """Fetch check runs for a commit from GitHub API.
+    """Fetch all check runs for a commit from GitHub API, following pagination.
 
     Returns:
-        List of check run dictionaries.
+        List of check run dictionaries across all pages.
 
     Raises:
         URLError: If the API request fails.
     """
-    url = f"https://api.github.com/repos/{repository}/commits/{ref}/check-runs"
+    runs: list[dict] = []
 
-    request = Request(url)  # noqa: S310
-    request.add_header("Authorization", f"Bearer {token}")
-    request.add_header("Accept", "application/vnd.github+json")
-    request.add_header("X-GitHub-Api-Version", "2022-11-28")
-    request.add_header("User-Agent", "wait-for-check-action")
+    for page in range(1, MAX_PAGES + 1):
+        url = f"https://api.github.com/repos/{repository}/commits/{ref}/check-runs?per_page={PER_PAGE}&page={page}"
 
-    with urlopen(request, timeout=30) as response:  # noqa: S310
-        data = json.loads(response.read().decode("utf-8"))
-        return data.get("check_runs", [])
+        request = Request(url)  # noqa: S310
+        request.add_header("Authorization", f"Bearer {token}")
+        request.add_header("Accept", "application/vnd.github+json")
+        request.add_header("X-GitHub-Api-Version", "2022-11-28")
+        request.add_header("User-Agent", "wait-for-check-action")
+
+        with urlopen(request, timeout=30) as response:  # noqa: S310
+            data = json.loads(response.read().decode("utf-8"))
+
+        batch = data.get("check_runs", [])
+        runs.extend(batch)
+
+        total = data.get("total_count", 0)
+        # stop once we've drained a short page or collected everything reported
+        if not batch or len(batch) < PER_PAGE or len(runs) >= total:
+            break
+    else:
+        # loop ran the full range without breaking: we hit the page cap and
+        # may not have examined every check run on the ref
+        print(
+            f"::warning::Reached pagination cap of {MAX_PAGES} pages "
+            f"({MAX_PAGES * PER_PAGE} check runs); some check runs may not have been examined.",
+        )
+
+    return runs
 
 
-def find_completed_check(check_runs: list[dict], check_name: str) -> str | None:
-    """Find a completed check with the given name.
+def _normalize(name: str) -> str:
+    """Fold case and trim whitespace so trivial name differences still match."""
+    return name.strip().casefold()
+
+
+def find_matching_checks(check_runs: list[dict], check_name: str) -> list[dict]:
+    """Return all check runs whose name matches check_name.
+
+    Matching is case-insensitive and whitespace-trimmed, but otherwise a full
+    name match (no partial/substring matching).
+    """
+    target = _normalize(check_name)
+    return [c for c in check_runs if _normalize(c.get("name") or "") == target]
+
+
+def resolve_conclusion(matches: list[dict]) -> str | None:
+    """Resolve a final conclusion from matching check runs.
+
+    Fails closed for duplicates: if multiple checks share the name, every one
+    must complete successfully. Returns None while any matching run is still
+    pending (we wait for the full set before deciding).
+
+    What counts as a "duplicate" here is worth being precise about, because it
+    determines whether this fail-closed branch ever fires:
+
+    - NOT re-runs / repeated attempts of the same job. The check-runs-for-ref
+      endpoint defaults to filter=latest, which collapses superseded attempts
+      within a check suite, so a re-run replaces (not duplicates) the prior run.
+    - IS two *different* workflows that each define a job with the same name on
+      the same commit. GitHub Actions creates one check suite per workflow run
+      (a single commit routinely has several Actions suites), and filter=latest
+      dedupes within a suite, not globally by name across the ref - so both
+      same-named runs are returned.
+    - IS a same-named check posted by a *different* app (e.g. a status-check bot
+      or external CI), which lives in its own suite and is likewise returned.
+
+    For a single repo today this is usually defensive rather than load-bearing:
+    job names are unique within a workflow, so duplicates only appear once a
+    second workflow (or app) reuses a gated check's name. Treating the worst
+    matching conclusion as the verdict keeps a name collision from silently
+    letting a failure through the gate.
 
     Returns:
-        The conclusion string if found and completed, None otherwise.
+        The conclusion string once all matching runs complete, None otherwise.
     """
-    for check in check_runs:
-        if check.get("name") == check_name and check.get("status") == "completed":
-            return check.get("conclusion")
-    return None
+    # no matches means nothing has resolved yet - never report success here
+    if not matches:
+        return None
+
+    if any(c.get("status") != "completed" for c in matches):
+        return None
+
+    # all matching runs completed: succeed only if every one succeeded,
+    # otherwise surface a non-success conclusion so the gate fails
+    for c in matches:
+        if c.get("conclusion") != "success":
+            return c.get("conclusion") or "failure"
+    return "success"
+
+
+def _seen_names(check_runs: list[dict]) -> list[str]:
+    """Return the sorted, de-duplicated set of check-run names seen."""
+    return sorted({(c.get("name") or "") for c in check_runs})
 
 
 def wait_for_check(config: Config) -> str:
     """Poll for a check to complete.
 
     Returns:
-        The check conclusion (e.g., "success", "failure", "timed_out").
+        The check conclusion (e.g., "success", "failure", "timed_out", "not_found").
     """
-    deadline = time.time() + config.timeout_seconds
+    start = time.time()
+    deadline = start + config.timeout_seconds
+    ever_seen = False
+    ever_fetched = False
+    last_error: Exception | None = None
+    last_seen_names: list[str] = []
 
     print(f"Waiting for check '{config.check_name}' on ref {config.ref}")
-    print(f"Timeout: {config.timeout_seconds}s, Interval: {config.interval_seconds}s")
+    print(
+        f"Timeout: {config.timeout_seconds}s, not-found timeout: "
+        f"{config.not_found_timeout_seconds}s, interval: {config.interval_seconds}s",
+    )
 
     while time.time() < deadline:
         try:
             check_runs = fetch_check_runs(config.token, config.repository, config.ref)
-            conclusion = find_completed_check(check_runs, config.check_name)
+            ever_fetched = True
+            last_error = None
+            last_seen_names = _seen_names(check_runs)
 
-            if conclusion is not None:
-                print(f"Check '{config.check_name}' completed with conclusion: {conclusion}")
-                return conclusion
+            if config.verbose:
+                print(f"Saw {len(check_runs)} check run(s) on ref: {', '.join(last_seen_names) or '(none)'}")
+
+            matches = find_matching_checks(check_runs, config.check_name)
+            if matches:
+                ever_seen = True
+                conclusion = resolve_conclusion(matches)
+                if conclusion is not None:
+                    print(f"Check '{config.check_name}' completed with conclusion: {conclusion}")
+                    return conclusion
 
         except (HTTPError, URLError) as e:
+            last_error = e
             print(f"::warning::API request failed: {e}", file=sys.stderr)
 
+        # give up early if the check name never shows up at all - this usually
+        # means a name mismatch (or an unreachable API) rather than a slow check
+        if not ever_seen and (time.time() - start) >= config.not_found_timeout_seconds:
+            _report_check_never_seen(
+                config,
+                ever_fetched=ever_fetched,
+                last_seen_names=last_seen_names,
+                last_error=last_error,
+                elapsed_label=f"after {config.not_found_timeout_seconds}s",
+            )
+            return "not_found"
+
         remaining = int(deadline - time.time())
-        print(f"Check '{config.check_name}' not complete yet. {remaining}s remaining...")
+        state = "seen, waiting to complete" if ever_seen else "not found yet"
+        print(f"Check '{config.check_name}' {state}. {remaining}s remaining...")
         time.sleep(config.interval_seconds)
 
-    print(f"::warning::Timed out after {config.timeout_seconds}s waiting for check '{config.check_name}'")
+    # full timeout reached
+    if ever_seen:
+        print(
+            f"::warning::Timed out after {config.timeout_seconds}s: check "
+            f"'{config.check_name}' was found but never reached a completed state.",
+        )
+    else:
+        _report_check_never_seen(
+            config,
+            ever_fetched=ever_fetched,
+            last_seen_names=last_seen_names,
+            last_error=last_error,
+            elapsed_label=f"after the full {config.timeout_seconds}s timeout",
+        )
     return "timed_out"
+
+
+def _report_check_never_seen(
+    config: Config,
+    *,
+    ever_fetched: bool,
+    last_seen_names: list[str],
+    last_error: Exception | None,
+    elapsed_label: str,
+) -> None:
+    """Explain why a named check never appeared, distinguishing the likely cause.
+
+    If we never managed a single successful API call, the check name says nothing -
+    the real problem is connectivity. Otherwise it almost always means the name does
+    not match any check run on the ref.
+    """
+    if not ever_fetched and last_error is not None:
+        print(
+            f"::error::Gave up {elapsed_label} on check '{config.check_name}' (ref {config.ref}): "
+            f"every GitHub API request failed, so check status could not be determined "
+            f"(last error: {last_error}).",
+        )
+        return
+
+    print(
+        f"::error::Check '{config.check_name}' was not found on ref {config.ref} {elapsed_label}. "
+        f"This usually means the check name does not match any check run (typo, wrong "
+        f"workflow, or the check never started).",
+    )
+    _report_available_checks(last_seen_names)
+
+
+def _report_available_checks(names: list[str]) -> None:
+    """Log the check names that were actually observed, to aid debugging mismatches."""
+    if not names:
+        print("::warning::No check runs were observed on the ref.")
+        return
+    print(f"Check runs observed on the ref ({len(names)}):")
+    for name in names:
+        print(f"  - {name}")
 
 
 def write_output(name: str, value: str) -> None:
@@ -186,6 +366,18 @@ def parse_args(args: list[str] | None = None) -> argparse.Namespace:
         default=30,
         help="Polling interval in seconds (default: 30)",
     )
+    parser.add_argument(
+        "--not-found-timeout-seconds",
+        type=int,
+        default=60,
+        help="Time to wait for the check to appear at all before giving up (default: 60)",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Log the check-run names seen on each poll",
+    )
     return parser.parse_args(args)
 
 
@@ -201,6 +393,8 @@ def main(args: list[str] | None = None) -> int:
             ref=parsed.ref,
             timeout_seconds=parsed.timeout_seconds,
             interval_seconds=parsed.interval_seconds,
+            not_found_timeout_seconds=parsed.not_found_timeout_seconds,
+            verbose=parsed.verbose,
         )
     except ValidationError as e:
         print(f"::error::Validation failed: {e}")

--- a/.github/workflows/check-gate.yaml
+++ b/.github/workflows/check-gate.yaml
@@ -39,6 +39,16 @@ on:
         description: "Polling interval in seconds"
         required: false
         default: 30
+      not-found-timeout-seconds:
+        type: number
+        description: "Time to wait for a check to appear at all before giving up"
+        required: false
+        default: 60
+      verbose:
+        type: boolean
+        description: "Log the check-run names seen on each poll"
+        required: false
+        default: false
 
 permissions: {}
 
@@ -122,6 +132,8 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
           timeout-seconds: ${{ inputs.timeout-seconds }}
           interval-seconds: ${{ inputs.interval-seconds }}
+          not-found-timeout-seconds: ${{ inputs.not-found-timeout-seconds }}
+          verbose: ${{ inputs.verbose }}
 
       - name: Report check result
         if: steps.wait.outputs.conclusion != 'success'

--- a/.github/workflows/check-gate.yaml
+++ b/.github/workflows/check-gate.yaml
@@ -43,7 +43,7 @@ on:
         type: number
         description: "Time to wait for a check to appear at all before giving up"
         required: false
-        default: 60
+        default: 90
       verbose:
         type: boolean
         description: "Log the check-run names seen on each poll"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,10 @@ on:
       version:
         description: tag the latest commit on main with the given version (prefixed with v)
         required: true
+      skip-checks:
+        description: skip the check gate that verifies required checks have passed on main
+        type: boolean
+        default: false
 
 jobs:
   version-available:
@@ -23,6 +27,8 @@ jobs:
       version: ${{ github.event.inputs.version }}
 
   check-gate:
+    # only run the gate when checks have not been explicitly skipped
+    if: ${{ !inputs.skip-checks }}
     permissions:
       checks: read # required for getting the status of specific check names
       contents: read # required for getting wait-for-check code
@@ -37,6 +43,8 @@ jobs:
     needs: [check-gate, version-available]
     environment: release # contains secrets needed for release
     runs-on: ubuntu-24.04
+    # run even when check-gate is skipped, but not when it failed or was cancelled
+    if: ${{ always() && !contains(fromJSON('["failure", "cancelled"]'), needs.check-gate.result) }}
     permissions:
       contents: write # needed for creating github release objects
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,8 +43,14 @@ jobs:
     needs: [check-gate, version-available]
     environment: release # contains secrets needed for release
     runs-on: ubuntu-24.04
-    # run even when check-gate is skipped, but not when it failed or was cancelled
-    if: ${{ always() && !contains(fromJSON('["failure", "cancelled"]'), needs.check-gate.result) }}
+    # run even when check-gate is skipped, but never when version-available
+    # failed/was skipped, nor when check-gate failed or was cancelled. note:
+    # always() disables the implicit success() gate on ALL needs, so the
+    # version-available requirement must be re-asserted explicitly here.
+    if: >-
+      ${{ always()
+          && needs.version-available.result == 'success'
+          && !contains(fromJSON('["failure", "cancelled"]'), needs.check-gate.result) }}
     permissions:
       contents: write # needed for creating github release objects
     steps:

--- a/.github/workflows/validations-wait-for-check.yaml
+++ b/.github/workflows/validations-wait-for-check.yaml
@@ -81,20 +81,22 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Wait for bogus check (should timeout)
+      - name: Wait for bogus check (should give up early as not_found)
         id: wait-bogus
         uses: ./.github/actions/wait-for-check
         with:
           token: ${{ github.token }}
           check-name: "this-check-does-not-exist-abc123"
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          timeout-seconds: 7
+          timeout-seconds: 12
           interval-seconds: 3
+          # shorter than timeout-seconds so the never-seen give-up fires first
+          not-found-timeout-seconds: 6
 
-      - name: Verify timeout conclusion
-        if: steps.wait-bogus.outputs.conclusion != 'timed_out'
+      - name: Verify not_found conclusion
+        if: steps.wait-bogus.outputs.conclusion != 'not_found'
         run: |
-          echo "::error::Expected 'timed_out' but got: ${STEPS_WAIT_BOGUS_OUTPUTS_CONCLUSION}"
+          echo "::error::Expected 'not_found' but got: ${STEPS_WAIT_BOGUS_OUTPUTS_CONCLUSION}"
           exit 1
         env:
           STEPS_WAIT_BOGUS_OUTPUTS_CONCLUSION: ${{ steps.wait-bogus.outputs.conclusion }}

--- a/.make/main.go
+++ b/.make/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"os"
+
 	. "github.com/anchore/go-make"
-	"github.com/anchore/go-make/run"
+	runopt "github.com/anchore/go-make/run"
 	"github.com/anchore/go-make/tasks/release"
 )
 
@@ -11,6 +13,14 @@ const (
 	runsonTestDir         = "tests"
 	waitForCheckActionDir = ".github/actions/wait-for-check"
 )
+
+// run wraps go-make's Run to stream stdout/stderr to the terminal. go-make's Run
+// captures stdout (returning it as a string) and only forwards stderr, so for our
+// tasks—whose return value we never use—the command's stdout is silently dropped.
+// Use this for any task command whose output the user should actually see.
+func run(cmd string, opts ...runopt.Option) {
+	Run(cmd, append([]runopt.Option{runopt.Stdout(os.Stdout), runopt.Stderr(os.Stderr)}, opts...)...)
+}
 
 func main() {
 	Makefile(
@@ -33,7 +43,7 @@ func main() {
 		Task{
 			Name:        "lint",
 			Description: "Lint github workflows",
-			Run:         func() { Run("wrkflw validate") },
+			Run:         func() { run("wrkflw validate") },
 		},
 
 		runsonTasks(),
@@ -52,38 +62,38 @@ func runsonTasks() Task {
 			{
 				Name:        "runson:lint",
 				Description: "Run ruff linter on runson code",
-				Run:         func() { Run("uv run ruff check .") },
+				Run:         func() { run("uv run ruff check .") },
 			},
 			{
 				Name:        "runson:lint-fix",
 				Description: "Run ruff linter with auto-fix on runson code",
-				Run:         func() { Run("uv run ruff check . --fix") },
+				Run:         func() { run("uv run ruff check . --fix") },
 			},
 			{
 				Name:        "runson:format",
 				Description: "Format runson code with ruff",
-				Run:         func() { Run("uv run ruff format .") },
+				Run:         func() { run("uv run ruff format .") },
 			},
 			{
 				Name:        "runson:format-check",
 				Description: "Check runson code formatting",
-				Run:         func() { Run("uv run ruff format --check .") },
+				Run:         func() { run("uv run ruff format --check .") },
 			},
 			{
 				Name:        "runson:check-types",
 				Description: "Run mypy type checker on runson code",
-				Run:         func() { Run("uv run mypy --config-file ./pyproject.toml " + runsonSrcDir) },
+				Run:         func() { run("uv run mypy --config-file ./pyproject.toml " + runsonSrcDir) },
 			},
 			{
 				Name:        "runson:test",
 				Description: "Run runson tests with pytest",
-				Run:         func() { Run("uv run pytest " + runsonTestDir + " -v") },
+				Run:         func() { run("uv run pytest " + runsonTestDir + " -v") },
 			},
 			{
 				Name:        "runson:test-cov",
 				Description: "Run runson tests with coverage",
 				Run: func() {
-					Run("uv run pytest " + runsonTestDir + " -v --cov=" + runsonSrcDir + " --cov-report=html")
+					run("uv run pytest " + runsonTestDir + " -v --cov=" + runsonSrcDir + " --cov-report=html")
 				},
 			},
 		},
@@ -93,7 +103,9 @@ func runsonTasks() Task {
 func waitForCheckTasks() Task {
 	// wait-for-check has its own pyproject.toml inside the action directory; tooling
 	// runs from there so ruff/pytest pick up the right config.
-	inDir := func(cmd string) { Run(cmd, run.InDir(waitForCheckActionDir)) }
+	inDir := func(cmd string) {
+		run(cmd, runopt.InDir(waitForCheckActionDir))
+	}
 	ruffCmd := func(args string) func() {
 		return func() {
 			inDir("pip install ruff -q")


### PR DESCRIPTION
This makes a few changes:
- We have only been fetching the first 30 recent checks on a reference, ignoring any additional checks that may exist. This ensures we're checking for the first 10 pages and increasing the page size to 100.
- If there is no check name we timeout in 10 minutes, but this is wasteful, if we haven't seen the check name (which is different than waiting for simply the status to show up) then we should bail sooner as something is wrong. This timeout has been added and is set to 90.
- Check names validated are now case insensitive
- Upon seeing duplicate check names then we will wait on all checks to pass, not just the first we see
- Added optional verbosity to debug issues as-needed (defaults to false)
- Will exit immediately on 401 http class issues (github uses 403 to convey secondary rate limits so we should still retry then)
- I also found that go-make tasks were not showing output --this has also been addressed
- I've updated the release pipeline to be able to break-glass and release even if checks are failing (given that any bug in this script would prevent updating it!)