### PR TITLE
Remove not-found timeout

### DIFF
--- a/.github/actions/wait-for-check/README.md
+++ b/.github/actions/wait-for-check/README.md
@@ -28,7 +28,6 @@ GitHub Actions workflows sometimes need to wait for other checks to complete bef
 | `ref` | Yes | - | Git ref (commit SHA) to check |
 | `timeout-seconds` | No | `600` | Maximum time to wait for a check to complete before timing out |
 | `interval-seconds` | No | `30` | How often to poll the GitHub API |
-| `not-found-timeout-seconds` | No | `90` | Time to wait for a check with the given name to appear at all (any status) before giving up early. Distinct from `timeout-seconds`, which bounds how long to wait for an already-seen check to complete |
 | `verbose` | No | `false` | Log the check-run names seen on each poll |
 
 ## Outputs
@@ -81,8 +80,7 @@ jobs:
 ## Behavior
 
 - Polls the GitHub API at the specified interval until the check completes or times out
-- Returns `timed_out` as the conclusion if the timeout is reached
-- Returns `not_found` if the named check never appears within `not-found-timeout-seconds` (typically a name mismatch or a check that never started)
+- Returns `timed_out` as the conclusion if the timeout is reached (if the named check never appeared, the failure message calls out the likely name mismatch and lists the checks that were observed)
 - Handles API errors gracefully with retries
 - Fails fast with conclusion `auth_error` on an HTTP 401 (invalid/missing token) rather than polling to the timeout
 - Honors GitHub rate limits: on a 403/429 carrying `Retry-After` or `x-ratelimit-reset`, it waits until the window resets (capped to the remaining timeout) instead of polling on the fixed interval

--- a/.github/actions/wait-for-check/action.yaml
+++ b/.github/actions/wait-for-check/action.yaml
@@ -19,10 +19,6 @@ inputs:
     description: 'Polling interval in seconds (default: 30)'
     required: false
     default: '30'
-  not-found-timeout-seconds:
-    description: 'Time to wait for the check to appear at all before giving up (default: 90)'
-    required: false
-    default: '90'
   verbose:
     description: 'Log the check-run names seen on each poll (default: false)'
     required: false
@@ -45,7 +41,6 @@ runs:
         INPUT_REF: ${{ inputs.ref }}
         INPUT_TIMEOUT: ${{ inputs.timeout-seconds }}
         INPUT_INTERVAL: ${{ inputs.interval-seconds }}
-        INPUT_NOT_FOUND_TIMEOUT: ${{ inputs.not-found-timeout-seconds }}
         INPUT_VERBOSE: ${{ inputs.verbose }}
         INPUT_REPOSITORY: ${{ github.repository }}
       run: |
@@ -60,5 +55,4 @@ runs:
           --ref "$INPUT_REF" \
           --timeout-seconds "$INPUT_TIMEOUT" \
           --interval-seconds "$INPUT_INTERVAL" \
-          --not-found-timeout-seconds "$INPUT_NOT_FOUND_TIMEOUT" \
           $verbose_flag

--- a/.github/actions/wait-for-check/test_wait_for_check.py
+++ b/.github/actions/wait-for-check/test_wait_for_check.py
@@ -106,31 +106,7 @@ class TestValidateConfig:
                 interval_seconds=-1,
             )
 
-    def test_invalid_not_found_timeout(self):
-        with pytest.raises(ValidationError, match="not_found_timeout_seconds must be positive"):
-            validate_config(
-                token="token",
-                repository="owner/repo",
-                check_name="test",
-                ref="abc123",
-                timeout_seconds=600,
-                interval_seconds=30,
-                not_found_timeout_seconds=0,
-            )
-
-    def test_not_found_timeout_not_less_than_timeout(self):
-        with pytest.raises(ValidationError, match="not_found_timeout_seconds.*must be less than"):
-            validate_config(
-                token="token",
-                repository="owner/repo",
-                check_name="test",
-                ref="abc123",
-                timeout_seconds=60,
-                interval_seconds=30,
-                not_found_timeout_seconds=60,
-            )
-
-    def test_not_found_timeout_and_verbose_defaults(self):
+    def test_verbose_default(self):
         config = validate_config(
             token="token",
             repository="owner/repo",
@@ -139,7 +115,6 @@ class TestValidateConfig:
             timeout_seconds=600,
             interval_seconds=30,
         )
-        assert config.not_found_timeout_seconds == 90
         assert config.verbose is False
 
     def test_interval_greater_than_timeout(self):
@@ -356,8 +331,6 @@ class TestParseArgs:
                 "300",
                 "--interval-seconds",
                 "15",
-                "--not-found-timeout-seconds",
-                "90",
                 "--verbose",
             ]
         )
@@ -367,7 +340,6 @@ class TestParseArgs:
         assert args.ref == "abc123"
         assert args.timeout_seconds == 300
         assert args.interval_seconds == 15
-        assert args.not_found_timeout_seconds == 90
         assert args.verbose is True
 
     def test_defaults(self):
@@ -385,7 +357,6 @@ class TestParseArgs:
         )
         assert args.timeout_seconds == 600
         assert args.interval_seconds == 30
-        assert args.not_found_timeout_seconds == 90
         assert args.verbose is False
 
     def test_missing_required_arg(self):
@@ -512,7 +483,6 @@ def _diag_config(**overrides):
         "ref": "abc123",
         "timeout_seconds": 10,
         "interval_seconds": 1,
-        "not_found_timeout_seconds": 3,
         "verbose": False,
     }
     base.update(overrides)
@@ -542,7 +512,7 @@ class TestWaitForCheckDiagnostics:
         result = wait_for_check(_diag_config())
 
         out = capsys.readouterr().out
-        assert result == "not_found"
+        assert result == "timed_out"
         assert "every GitHub API request failed" in out
         assert "does not match" not in out
 
@@ -557,7 +527,7 @@ class TestWaitForCheckDiagnostics:
         result = wait_for_check(_diag_config())
 
         out = capsys.readouterr().out
-        assert result == "not_found"
+        assert result == "timed_out"
         assert "does not match" in out
         assert "Other" in out
 
@@ -571,7 +541,7 @@ class TestWaitForCheckDiagnostics:
         assert wait_for_check(_diag_config()) == "success"
 
     def test_seen_but_never_completes_times_out(self, monkeypatch, capsys):
-        """A check that is found but stays in_progress past the timeout is timed_out, not not_found."""
+        """A check found but stuck in_progress times out with the seen (not the never-seen) diagnostics."""
         _freeze_clock(monkeypatch)
         monkeypatch.setattr(
             "wait_for_check.fetch_check_runs",
@@ -667,7 +637,7 @@ class TestWaitForCheckRateLimits:
 
         monkeypatch.setattr("wait_for_check.fetch_check_runs", flaky)
 
-        result = wait_for_check(_diag_config(timeout_seconds=600, not_found_timeout_seconds=120))
+        result = wait_for_check(_diag_config(timeout_seconds=600))
 
         assert result == "success"
         assert sleeps == [45]
@@ -689,7 +659,7 @@ class TestWaitForCheckRateLimits:
 
         monkeypatch.setattr("wait_for_check.fetch_check_runs", flaky)
 
-        result = wait_for_check(_diag_config(timeout_seconds=600, not_found_timeout_seconds=120))
+        result = wait_for_check(_diag_config(timeout_seconds=600))
 
         assert result == "success"
         assert sleeps == [30]
@@ -721,7 +691,7 @@ class TestWaitForCheckRateLimits:
 
         monkeypatch.setattr("wait_for_check.fetch_check_runs", always_rate_limited)
 
-        result = wait_for_check(_diag_config(timeout_seconds=10, not_found_timeout_seconds=9))
+        result = wait_for_check(_diag_config(timeout_seconds=10))
 
         assert result == "timed_out"
         # never slept longer than the remaining budget

--- a/.github/actions/wait-for-check/wait_for_check.py
+++ b/.github/actions/wait-for-check/wait_for_check.py
@@ -34,10 +34,6 @@ class Config(NamedTuple):
     ref: str
     timeout_seconds: int
     interval_seconds: int
-    # how long to wait for a check with the given name to appear at all (any
-    # status) before giving up early. distinct from timeout_seconds, which
-    # bounds how long we wait for an already-seen check to complete.
-    not_found_timeout_seconds: int = 90
     verbose: bool = False
 
 
@@ -52,7 +48,6 @@ def validate_config(
     ref: str | None,
     timeout_seconds: int,
     interval_seconds: int,
-    not_found_timeout_seconds: int = 90,
     verbose: bool = False,
 ) -> Config:
     """Validate all inputs and return a Config object.
@@ -88,15 +83,6 @@ def validate_config(
     if interval_seconds >= timeout_seconds:
         errors.append(f"interval_seconds ({interval_seconds}) must be less than timeout_seconds ({timeout_seconds})")
 
-    if not_found_timeout_seconds <= 0:
-        errors.append(f"not_found_timeout_seconds must be positive, got: {not_found_timeout_seconds}")
-    elif not_found_timeout_seconds >= timeout_seconds:
-        # otherwise the early give-up never fires - the full timeout is reached first
-        errors.append(
-            f"not_found_timeout_seconds ({not_found_timeout_seconds}) must be less than "
-            f"timeout_seconds ({timeout_seconds})"
-        )
-
     if errors:
         raise ValidationError("; ".join(errors))
 
@@ -107,7 +93,6 @@ def validate_config(
         ref=ref,  # type: ignore[arg-type]
         timeout_seconds=timeout_seconds,
         interval_seconds=interval_seconds,
-        not_found_timeout_seconds=not_found_timeout_seconds,
         verbose=verbose,
     )
 
@@ -258,7 +243,7 @@ def wait_for_check(config: Config) -> str:
     """Poll for a check to complete.
 
     Returns:
-        The check conclusion (e.g., "success", "failure", "timed_out", "not_found",
+        The check conclusion (e.g., "success", "failure", "timed_out",
         "auth_error").
     """
     start = time.time()
@@ -269,10 +254,7 @@ def wait_for_check(config: Config) -> str:
     last_seen_names: list[str] = []
 
     print(f"Waiting for check '{config.check_name}' on ref {config.ref}")
-    print(
-        f"Timeout: {config.timeout_seconds}s, not-found timeout: "
-        f"{config.not_found_timeout_seconds}s, interval: {config.interval_seconds}s",
-    )
+    print(f"Timeout: {config.timeout_seconds}s, interval: {config.interval_seconds}s")
 
     while time.time() < deadline:
         # how long to wait before the next poll; a rate-limit response overrides this
@@ -322,18 +304,6 @@ def wait_for_check(config: Config) -> str:
         except URLError as e:
             last_error = e
             print(f"::warning::API request failed: {e}", file=sys.stderr)
-
-        # give up early if the check name never shows up at all - this usually
-        # means a name mismatch (or an unreachable API) rather than a slow check
-        if not ever_seen and (time.time() - start) >= config.not_found_timeout_seconds:
-            _report_check_never_seen(
-                config,
-                ever_fetched=ever_fetched,
-                last_seen_names=last_seen_names,
-                last_error=last_error,
-                elapsed_label=f"after {config.not_found_timeout_seconds}s",
-            )
-            return "not_found"
 
         remaining = deadline - time.time()
         if remaining <= 0:
@@ -441,12 +411,6 @@ def parse_args(args: list[str] | None = None) -> argparse.Namespace:
         help="Polling interval in seconds (default: 30)",
     )
     parser.add_argument(
-        "--not-found-timeout-seconds",
-        type=int,
-        default=90,
-        help="Time to wait for the check to appear at all before giving up (default: 90)",
-    )
-    parser.add_argument(
         "-v",
         "--verbose",
         action="store_true",
@@ -467,7 +431,6 @@ def main(args: list[str] | None = None) -> int:
             ref=parsed.ref,
             timeout_seconds=parsed.timeout_seconds,
             interval_seconds=parsed.interval_seconds,
-            not_found_timeout_seconds=parsed.not_found_timeout_seconds,
             verbose=parsed.verbose,
         )
     except ValidationError as e:

--- a/.github/workflows/check-gate.yaml
+++ b/.github/workflows/check-gate.yaml
@@ -39,11 +39,6 @@ on:
         description: "Polling interval in seconds"
         required: false
         default: 30
-      not-found-timeout-seconds:
-        type: number
-        description: "Time to wait for a check to appear at all before giving up"
-        required: false
-        default: 90
       verbose:
         type: boolean
         description: "Log the check-run names seen on each poll"
@@ -132,7 +127,6 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
           timeout-seconds: ${{ inputs.timeout-seconds }}
           interval-seconds: ${{ inputs.interval-seconds }}
-          not-found-timeout-seconds: ${{ inputs.not-found-timeout-seconds }}
           verbose: ${{ inputs.verbose }}
 
       - name: Report check result

--- a/.github/workflows/validations-wait-for-check.yaml
+++ b/.github/workflows/validations-wait-for-check.yaml
@@ -81,7 +81,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Wait for bogus check (should give up early as not_found)
+      - name: Wait for bogus check (should time out, never seen)
         id: wait-bogus
         uses: ./.github/actions/wait-for-check
         with:
@@ -90,13 +90,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           timeout-seconds: 12
           interval-seconds: 3
-          # shorter than timeout-seconds so the never-seen give-up fires first
-          not-found-timeout-seconds: 6
 
-      - name: Verify not_found conclusion
-        if: steps.wait-bogus.outputs.conclusion != 'not_found'
+      - name: Verify timed_out conclusion
+        if: steps.wait-bogus.outputs.conclusion != 'timed_out'
         run: |
-          echo "::error::Expected 'not_found' but got: ${STEPS_WAIT_BOGUS_OUTPUTS_CONCLUSION}"
+          echo "::error::Expected 'timed_out' but got: ${STEPS_WAIT_BOGUS_OUTPUTS_CONCLUSION}"
           exit 1
         env:
           STEPS_WAIT_BOGUS_OUTPUTS_CONCLUSION: ${{ steps.wait-bogus.outputs.conclusion }}


### PR DESCRIPTION
Follow up to #107 which introduced the idea to have a separate timeout for names that are not found at all. This is flawed since it's a bad assumption that a name should exist relatively near the beginning of a workflow.